### PR TITLE
chore: bootstrap ci-framework v2.5.1 on development

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,70 +1,62 @@
-name: Package CI
+name: CI
 
 on:
   push:
-    branches: [main, master, develop, development]
+    branches: [main, development]
   pull_request:
-    branches: [main, master, develop, development]
-  workflow_dispatch:
+    branches: [main, development]
+
+# Cancel in-progress CI runs for the same ref/branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  test:
+  ci:
+    uses: Claire-s-Monster/ci-framework/.github/workflows/reusable-ci.yml@v2.5.1
+    permissions:
+      contents: write
+      id-token: write
+      pull-requests: write
+      actions: read
+      checks: write
+    with:
+      pixi-environment: "ci"
+      python-versions: '["3.10", "3.11", "3.12"]'
+      os-matrix: '["ubuntu-latest"]'
+      enable-performance: false
+      enable-release: false
+      enable-hygiene-check: true
+      editable-install: true
+      package-path: "."
+      allowed-licenses: "MIT, Apache-2.0, BSD-3-Clause, BSD-2-Clause, ISC"
+    secrets: inherit
+
+  branch-policy:
+    name: "Branch Policy"
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.10"]
-    defaults:
-      run:
-        shell: bash
-
+    if: github.event_name == 'pull_request' && github.base_ref == 'main'
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Pixi
-        uses: prefix-dev/setup-pixi@v0.8.8
-
-      - name: Install project dependencies (using Pixi)
+      - name: Check source branch
         run: |
-          pixi install # This will install dependencies based on pyproject.toml and create/use pixi.lock
-          pixi run pip install -e .
+          if [ "${{ github.head_ref }}" != "development" ]; then
+            echo "PRs to main must come from development branch"
+            echo "  Source: ${{ github.head_ref }}"
+            echo "  Expected: development"
+            exit 1
+          fi
+          echo "PR from development to main - allowed"
 
-      - name: Run unit tests with coverage
-        run: |
-          # Run unit tests first to avoid URL patching pollution from integration tests
-          pixi run pytest tests -m "not integration" --cov=candles_feed --cov-report=xml:coverage.xml
-          
-      - name: Run integration tests separately
-        run: |
-          # Run integration tests separately to prevent URL patching pollution
-          pixi run pytest tests -m "integration" --cov=candles_feed --cov-append
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
-        with:
-          file: ./coverage.xml
-          fail_ci_if_error: false
-
-  lint:
+  ci-success:
+    name: "CI Success"
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
-
+    needs: [ci]
+    if: always()
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Pixi
-        uses: prefix-dev/setup-pixi@v0.8.8
-
-      - name: Install project dependencies (using Pixi)
+      - name: Check CI status
         run: |
-          pixi install # This will install dependencies based on pyproject.toml
-          pixi run pip install -e .
-
-      - name: Format and lint with ruff
-        run: |
-          pixi run ci-check
-
-      - name: Type check with mypy
-        run: |
-          pixi run ci-hints
+          if [ "${{ needs.ci.result }}" != "success" ]; then
+            echo "CI failed with result: ${{ needs.ci.result }}"
+            exit 1
+          fi
+          echo "All CI checks passed"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,18 +89,18 @@ test-unit = "pytest tests/unit"
 test-integration = "pytest tests/integration"
 lint = "ruff check candles_feed tests"
 format = "ruff format candles_feed tests"
+format-check = "ruff format --check candles_feed tests"
 typecheck = "mypy candles_feed"
+type-check = "mypy candles_feed"
+security = "bandit -c pyproject.toml -r candles_feed/"
 lint-cython = "cython-lint candles_feed"
-check = { cmd = ["pixi run format", "pixi run lint", "pixi run typecheck", "pixi run test"] }
+quality = { depends-on = ["lint", "type-check"] }
+check = { depends-on = ["format", "lint", "type-check", "test"] }
 
 # Documentation tasks
 docs-build = "mkdocs build --clean --strict"
 docs-serve = "mkdocs serve --dev-addr localhost:8008"
 docs-deploy = "mkdocs gh-deploy"
-
-# CI tasks
-ci-check = "ruff check candles_feed tests; ruff format --check candles_feed tests"
-ci-hints = "mypy --install-types --non-interactive --ignore-missing-imports candles_feed/"
 
 # Features
 [tool.pixi.feature.docs.dependencies]
@@ -125,6 +125,12 @@ mypy = ">=1.5.1"
 cython-lint = ">=0.15.0"
 
 [tool.pixi.feature.ci.dependencies]
+ruff = ">=0.1.6"
+mypy = ">=1.5.1"
+pytest = ">=7.0.0"
+pytest-cov = ">=4.1.0"
+bandit = ">=1.8.0"
+pre-commit = ">=2.15.0"
 types-setuptools = "*"
 
 # Environments
@@ -212,3 +218,7 @@ check_untyped_defs = false
 exclude = [
     "candles_feed/mocking_resources/.*",
 ]
+
+[tool.bandit]
+exclude_dirs = ["tests"]
+skips = ["B101"]


### PR DESCRIPTION
## Summary

- Replace custom Package CI workflow with ci-framework v2.5.1 reusable workflow
- Add ci-framework-required pixi tasks: type-check, format-check, security, quality
- Expand pixi ci feature dependencies (ruff, mypy, pytest, bandit, pre-commit)
- Add bandit security scanning configuration
- Add CI Success gate job and Branch Policy enforcement

## Why

Bootstraps ci-framework on development so subsequent PRs trigger ci-framework CI checks. GitHub requires workflow files on the base branch for pull_request triggers.

## Test plan

- CI workflow triggers after merge (push event)
- ci-framework jobs run: hygiene, quality, test, security, build
- CI / CI Success check appears in PR checks

## Summary by Sourcery

Adopt the shared ci-framework v2.5.1 workflow for CI and introduce branch/CI success gating around main and development branches.

Enhancements:
- Replace the existing bespoke CI workflow with the reusable ci-framework v2.5.1 workflow, including concurrency control and a consolidated CI job.
- Add a branch policy job that restricts PRs into main to originate from the development branch.
- Introduce a CI success gate job that enforces overall CI success before passing the final check.
- Expand Pixi CI feature dependencies to include linting, typing, testing, coverage, security, and pre-commit tools.
- Define new Pixi tasks for format checking, type checking, security scanning, and quality aggregation, and simplify the main check task to depend on these.

Tests:
- Configure Bandit security scanning via a new Pixi task and Bandit settings in pyproject, excluding tests and skipping rule B101.