### PR TITLE
chore: bootstrap ci-framework v2.5.1 on development

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "pip"
     directory: "/"
+    target-branch: "development"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
@@ -13,6 +14,7 @@ updates:
 
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "development"
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 5


### PR DESCRIPTION
Replace custom Package CI with ci-framework v2.5.1 reusable workflow. Add ci-framework-required pixi tasks and dependencies. Target dependabot PRs to development. This enables ci-framework CI checks for all subsequent PRs targeting development.

## Summary by Sourcery

CI:
- Update Dependabot configuration so pip and GitHub Actions updates open pull requests against the development branch.