### PR TITLE
fix: remove invalid enable-release input causing CI startup_failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,6 @@ jobs:
       python-versions: '["3.10", "3.11", "3.12"]'
       os-matrix: '["ubuntu-latest"]'
       enable-performance: false
-      enable-release: false
       enable-hygiene-check: true
       editable-install: true
       package-path: "."


### PR DESCRIPTION
The ci-framework reusable workflow does not accept enable-release as an input. Passing unknown inputs causes GitHub Actions startup_failure. This fixes all CI runs on development.

## Summary by Sourcery

CI:
- Update CI workflow configuration to stop passing the invalid enable-release input to the reusable ci-framework workflow.