### PR TITLE
fix: disable cleanup-dev-files workflow until bot secrets configured

### DIFF
--- a/.github/workflows/cleanup-dev-files.yml
+++ b/.github/workflows/cleanup-dev-files.yml
@@ -1,24 +1,35 @@
 ---
 name: Cleanup Development Artifacts
 
+# Disabled: requires CI_BOT_TOKEN, CI_BOT_GPG_KEY, CI_BOT_GPG_KEY_ID secrets
+# Re-enable when bot secrets are configured in repository settings
+# on:
+#   push:
+#     branches: [main, development]
+#   schedule:
+#     - cron: '0 2 * * *'
+#   workflow_dispatch:
+#     inputs:
+#       target_branch:
+#         description: 'Branch to clean'
+#         required: false
+#         default: 'development'
+#         type: choice
+#         options:
+#           - main
+#           - development
+
 on:
-  push:
-    branches: [main, development]
-  schedule:
-    - cron: '0 2 * * *'
   workflow_dispatch:
     inputs:
-      target_branch:
-        description: 'Branch to clean'
+      placeholder:
+        description: 'Disabled until bot secrets are configured'
         required: false
-        default: 'development'
-        type: choice
-        options:
-          - main
-          - development
+        default: 'disabled'
 
 jobs:
   cleanup:
+    if: false
     uses: Claire-s-Monster/ci-framework/.github/workflows/cleanup-dev-files.yml@v2.5.1
     with:
       target_branches: >-


### PR DESCRIPTION
## Summary

- Disable `cleanup-dev-files.yml` workflow with `if: false` and comment out auto-triggers
- The ci-framework cleanup reusable workflow requires `CI_BOT_TOKEN`, `CI_BOT_GPG_KEY`, `CI_BOT_GPG_KEY_ID` secrets which aren't configured
- Preserves workflow config so it can be re-enabled when secrets are set up

## Test plan
- [ ] Cleanup workflow no longer triggers on push to main/development
- [ ] CI checks pass without cleanup failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Disable automatic triggers for the cleanup-dev-files workflow and guard its job execution with a false condition so it no longer runs without required CI bot secrets.