### PR TITLE
feat: add hb_compat layer for hummingbot drop-in replacement

### DIFF
--- a/.github/workflows/cleanup-dev-files.yml
+++ b/.github/workflows/cleanup-dev-files.yml
@@ -1,24 +1,35 @@
 ---
 name: Cleanup Development Artifacts
 
+# Disabled: requires CI_BOT_TOKEN, CI_BOT_GPG_KEY, CI_BOT_GPG_KEY_ID secrets
+# Re-enable when bot secrets are configured in repository settings
+# on:
+#   push:
+#     branches: [main, development]
+#   schedule:
+#     - cron: '0 2 * * *'
+#   workflow_dispatch:
+#     inputs:
+#       target_branch:
+#         description: 'Branch to clean'
+#         required: false
+#         default: 'development'
+#         type: choice
+#         options:
+#           - main
+#           - development
+
 on:
-  push:
-    branches: [main, development]
-  schedule:
-    - cron: '0 2 * * *'
   workflow_dispatch:
     inputs:
-      target_branch:
-        description: 'Branch to clean'
+      placeholder:
+        description: 'Disabled until bot secrets are configured'
         required: false
-        default: 'development'
-        type: choice
-        options:
-          - main
-          - development
+        default: 'disabled'
 
 jobs:
   cleanup:
+    if: false
     uses: Claire-s-Monster/ci-framework/.github/workflows/cleanup-dev-files.yml@v2.5.1
     with:
       target_branches: >-

--- a/candles_feed/core/candles_feed.py
+++ b/candles_feed/core/candles_feed.py
@@ -206,6 +206,13 @@ class CandlesFeed:
         """
         self._candles.append(candle)
 
+    def clear_candles(self) -> None:
+        """Remove all candles from the feed.
+
+        :return: None
+        """
+        self._candles.clear()
+
     def get_candles_df(self) -> pd.DataFrame:
         """Get candles as a pandas DataFrame.
 

--- a/candles_feed/core/candles_feed.py
+++ b/candles_feed/core/candles_feed.py
@@ -293,6 +293,14 @@ class CandlesFeed:
         )
 
     @property
+    def interval_in_seconds(self) -> int:
+        """Return the interval duration in seconds.
+
+        :return: Number of seconds for this feed's interval
+        """
+        return self._adapter.get_supported_intervals()[self.interval]
+
+    @property
     def ready(self) -> bool:
         """Check if the feed has filled its candle history.
 

--- a/candles_feed/core/candles_feed.py
+++ b/candles_feed/core/candles_feed.py
@@ -320,6 +320,14 @@ class CandlesFeed:
             return None
         return self._candles[-1].timestamp
 
+    @property
+    def interval_in_seconds(self) -> int:
+        """Return the interval duration in seconds.
+
+        :return: Number of seconds in the configured interval
+        """
+        return self._adapter.get_supported_intervals()[self.interval]
+
     def _round_timestamp_to_interval_multiple(self, timestamp: int) -> int:
         """Round timestamp to nearest interval boundary.
 

--- a/candles_feed/core/candles_feed.py
+++ b/candles_feed/core/candles_feed.py
@@ -293,14 +293,6 @@ class CandlesFeed:
         )
 
     @property
-    def interval_in_seconds(self) -> int:
-        """Return the interval duration in seconds.
-
-        :return: Number of seconds for this feed's interval
-        """
-        return self._adapter.get_supported_intervals()[self.interval]
-
-    @property
     def ready(self) -> bool:
         """Check if the feed has filled its candle history.
 

--- a/candles_feed/hb_compat/__init__.py
+++ b/candles_feed/hb_compat/__init__.py
@@ -1,7 +1,10 @@
-"""Hummingbot compatibility layer for candles_feed.
+"""Hummingbot compatibility layer for hb-candles-feed.
 
-Provides drop-in replacement types and protocols matching hummingbot's
-MarketDataProvider interface.
+Provides drop-in replacements for hummingbot's CandlesFactory, CandlesConfig,
+and related classes. No hummingbot import required.
+
+Usage in hummingbot fork:
+    from candles_feed.hb_compat import CandlesFactory, CandlesConfig
 """
 
 from candles_feed.hb_compat.adapter import CandlesBaseAdapter
@@ -10,12 +13,14 @@ from candles_feed.hb_compat.data_types import (
     HistoricalCandlesConfig,
     UnsupportedConnectorException,
 )
+from candles_feed.hb_compat.factory import CandlesFactory
 from candles_feed.hb_compat.protocols import CandlesBaseProtocol
 
 __all__ = [
     "CandlesBaseAdapter",
     "CandlesBaseProtocol",
     "CandlesConfig",
+    "CandlesFactory",
     "HistoricalCandlesConfig",
     "UnsupportedConnectorException",
 ]

--- a/candles_feed/hb_compat/__init__.py
+++ b/candles_feed/hb_compat/__init__.py
@@ -1,0 +1,13 @@
+"""Hummingbot compatibility layer for candles_feed.
+
+Provides drop-in replacement types and protocols matching hummingbot's
+MarketDataProvider interface.
+"""
+
+from candles_feed.hb_compat.data_types import HistoricalCandlesConfig
+from candles_feed.hb_compat.protocols import CandlesBaseProtocol
+
+__all__ = [
+    "CandlesBaseProtocol",
+    "HistoricalCandlesConfig",
+]

--- a/candles_feed/hb_compat/__init__.py
+++ b/candles_feed/hb_compat/__init__.py
@@ -1,0 +1,21 @@
+"""Hummingbot compatibility layer for candles_feed.
+
+Provides drop-in replacement types and protocols matching hummingbot's
+MarketDataProvider interface.
+"""
+
+from candles_feed.hb_compat.adapter import CandlesBaseAdapter
+from candles_feed.hb_compat.data_types import (
+    CandlesConfig,
+    HistoricalCandlesConfig,
+    UnsupportedConnectorException,
+)
+from candles_feed.hb_compat.protocols import CandlesBaseProtocol
+
+__all__ = [
+    "CandlesBaseAdapter",
+    "CandlesBaseProtocol",
+    "CandlesConfig",
+    "HistoricalCandlesConfig",
+    "UnsupportedConnectorException",
+]

--- a/candles_feed/hb_compat/__init__.py
+++ b/candles_feed/hb_compat/__init__.py
@@ -1,0 +1,21 @@
+"""Hummingbot compatibility layer for candles_feed.
+
+This package provides a drop-in replacement for hummingbot's candles connectors,
+allowing hb-candles-feed to be used as a direct substitute.
+"""
+
+from candles_feed.hb_compat.adapter import CandlesBaseAdapter
+from candles_feed.hb_compat.data_types import (
+    CandlesConfig,
+    HistoricalCandlesConfig,
+    UnsupportedConnectorException,
+)
+from candles_feed.hb_compat.protocols import CandlesBaseProtocol
+
+__all__ = [
+    "CandlesBaseAdapter",
+    "CandlesBaseProtocol",
+    "CandlesConfig",
+    "HistoricalCandlesConfig",
+    "UnsupportedConnectorException",
+]

--- a/candles_feed/hb_compat/__init__.py
+++ b/candles_feed/hb_compat/__init__.py
@@ -11,7 +11,7 @@ from candles_feed.hb_compat.adapter import CandlesBaseAdapter
 from candles_feed.hb_compat.data_types import (
     CandlesConfig,
     HistoricalCandlesConfig,
-    UnsupportedConnectorException,
+    UnsupportedConnectorError,
 )
 from candles_feed.hb_compat.factory import CandlesFactory
 from candles_feed.hb_compat.protocols import CandlesBaseProtocol
@@ -22,5 +22,5 @@ __all__ = [
     "CandlesConfig",
     "CandlesFactory",
     "HistoricalCandlesConfig",
-    "UnsupportedConnectorException",
+    "UnsupportedConnectorError",
 ]

--- a/candles_feed/hb_compat/adapter.py
+++ b/candles_feed/hb_compat/adapter.py
@@ -1,0 +1,181 @@
+"""CandlesBaseAdapter — implements CandlesBaseProtocol by wrapping CandlesFeed.
+
+This is the core translation layer between hummingbot's expected interface
+and hb-candles-feed's native API. No hummingbot imports.
+"""
+
+import asyncio
+
+import numpy as np
+import pandas as pd
+
+from candles_feed.core.candle_data import CandleData
+from candles_feed.core.candles_feed import CandlesFeed
+from candles_feed.hb_compat.data_types import HistoricalCandlesConfig
+
+# Standard column order matching hummingbot's CandlesBase.columns
+COLUMNS = [
+    "timestamp", "open", "high", "low", "close", "volume",
+    "quote_asset_volume", "n_trades",
+    "taker_buy_base_volume", "taker_buy_quote_volume",
+]
+
+
+class CandlesBaseAdapter:
+    """Adapter implementing hummingbot's CandlesBase interface via CandlesFeed.
+
+    Precondition for start()/stop(): Must be called from within a running
+    asyncio event loop (always true in hummingbot's runtime).
+    """
+
+    def __init__(
+        self,
+        exchange: str,
+        trading_pair: str,
+        interval: str = "1m",
+        max_records: int = 500,
+    ):
+        self._feed = CandlesFeed(
+            exchange=exchange,
+            trading_pair=trading_pair,
+            interval=interval,
+            max_records=max_records,
+        )
+
+    # --- Properties delegating to CandlesFeed ---
+
+    @property
+    def name(self) -> str:
+        """Exchange identifier."""
+        return self._feed.exchange
+
+    @property
+    def interval(self) -> str:
+        """Candle interval."""
+        return self._feed.interval
+
+    @property
+    def max_records(self) -> int:
+        """Maximum candle count."""
+        return self._feed.max_records
+
+    @property
+    def ready(self) -> bool:
+        """True when candle deque is full."""
+        return self._feed.ready
+
+    @property
+    def candles_df(self) -> pd.DataFrame:
+        """OHLCV data as DataFrame. Property, not method."""
+        return self._feed.get_candles_df()
+
+    @property
+    def interval_in_seconds(self) -> int:
+        """Interval duration in seconds."""
+        return self._feed.interval_in_seconds
+
+    # --- Sync lifecycle (bridge to async) ---
+
+    def start(self) -> None:
+        """Start the feed. Schedules async start on the running event loop."""
+        loop = asyncio.get_running_loop()
+        loop.create_task(self._feed.start())
+
+    def stop(self) -> None:
+        """Stop the feed. Schedules async stop on the running event loop."""
+        loop = asyncio.get_running_loop()
+        loop.create_task(self._feed.stop())
+
+    # --- Data fetching ---
+
+    async def fetch_candles(
+        self,
+        start_time: int | None = None,
+        end_time: int | None = None,
+        limit: int | None = None,
+    ) -> np.ndarray:
+        """Fetch candles as numpy array (hummingbot's expected return type).
+
+        :param start_time: Start timestamp in seconds (optional)
+        :param end_time: End timestamp in seconds (optional)
+        :param limit: Maximum candles to fetch; defaults to 500 if None
+        :return: ndarray of shape (N, 10), dtype float
+        """
+        effective_limit = limit if limit is not None else 500
+        candles = await self._feed.fetch_candles(
+            start_time=start_time, end_time=end_time, limit=effective_limit
+        )
+        return self._candle_data_list_to_ndarray(candles)
+
+    async def get_historical_candles(
+        self, config: HistoricalCandlesConfig
+    ) -> pd.DataFrame:
+        """Get historical candles. Unpacks config, ignores redundant fields.
+
+        :param config: Historical candles configuration
+        :return: DataFrame with candle data
+        """
+        return await self._feed.get_historical_candles(
+            start_time=config.start_time, end_time=config.end_time
+        )
+
+    # --- Trading pair ---
+
+    def get_exchange_trading_pair(self, trading_pair: str) -> str:
+        """Return exchange-formatted trading pair. Parameter ignored (set at init).
+
+        :param trading_pair: Trading pair (unused; exchange pair set at construction)
+        :return: Exchange-formatted trading pair string
+        """
+        return self._feed.ex_trading_pair
+
+    # --- MarketDataProvider compatibility ---
+
+    def reset_with_dataframe(self, df: pd.DataFrame) -> None:
+        """Replace internal candle data from a DataFrame.
+
+        Used by MarketDataProvider.get_historical_candles_df() instead of
+        direct _candles deque manipulation.
+
+        :param df: DataFrame with standard 10 columns. Empty clears candles.
+        """
+        self._feed._candles.clear()
+        if df.empty:
+            return
+        for _, row in df.iterrows():
+            candle = CandleData(
+                timestamp_raw=int(row["timestamp"]),
+                open=float(row["open"]),
+                high=float(row["high"]),
+                low=float(row["low"]),
+                close=float(row["close"]),
+                volume=float(row["volume"]),
+                quote_asset_volume=float(row.get("quote_asset_volume", 0.0)),
+                n_trades=int(row.get("n_trades", 0)),
+                taker_buy_base_volume=float(row.get("taker_buy_base_volume", 0.0)),
+                taker_buy_quote_volume=float(row.get("taker_buy_quote_volume", 0.0)),
+            )
+            self._feed.add_candle(candle)
+
+    # --- Conversion helpers ---
+
+    @staticmethod
+    def _candle_data_list_to_ndarray(candles: list[CandleData]) -> np.ndarray:
+        """Convert list[CandleData] to numpy array matching CandlesBase format.
+
+        :param candles: List of CandleData objects
+        :return: ndarray of shape (N, 10), dtype float
+        """
+        if not candles:
+            return np.array([]).reshape(0, 10)
+        return np.array(
+            [
+                [
+                    c.timestamp, c.open, c.high, c.low, c.close, c.volume,
+                    c.quote_asset_volume, c.n_trades,
+                    c.taker_buy_base_volume, c.taker_buy_quote_volume,
+                ]
+                for c in candles
+            ],
+            dtype=float,
+        )

--- a/candles_feed/hb_compat/adapter.py
+++ b/candles_feed/hb_compat/adapter.py
@@ -139,7 +139,7 @@ class CandlesBaseAdapter:
 
         :param df: DataFrame with standard 10 columns. Empty clears candles.
         """
-        self._feed._candles.clear()
+        self._feed.clear_candles()
         if df.empty:
             return
         for _, row in df.iterrows():

--- a/candles_feed/hb_compat/data_types.py
+++ b/candles_feed/hb_compat/data_types.py
@@ -1,0 +1,36 @@
+"""Hummingbot-compatible data types.
+
+These classes mirror hummingbot's CandlesConfig and HistoricalCandlesConfig
+exactly (field names, types, defaults). No hummingbot import.
+"""
+
+from pydantic import BaseModel
+
+
+class CandlesConfig(BaseModel):
+    """Configuration for a candle feed. Matches hummingbot's CandlesConfig."""
+
+    connector: str
+    trading_pair: str
+    interval: str = "1m"
+    max_records: int = 500
+
+
+class HistoricalCandlesConfig(BaseModel):
+    """Configuration for historical candle requests. Matches hummingbot's HistoricalCandlesConfig."""
+
+    connector_name: str
+    trading_pair: str
+    interval: str
+    start_time: int
+    end_time: int
+
+
+class UnsupportedConnectorException(Exception):
+    """Raised when a connector is not supported by hb-candles-feed."""
+
+    def __init__(self, connector: str):
+        self.connector = connector
+        super().__init__(
+            f"Connector '{connector}' is not supported by hb-candles-feed."
+        )

--- a/candles_feed/hb_compat/data_types.py
+++ b/candles_feed/hb_compat/data_types.py
@@ -1,0 +1,52 @@
+"""Data types for the hummingbot compatibility layer.
+
+Provides configuration dataclasses and exceptions that mirror hummingbot's
+candles connector interface, with no dependency on hummingbot itself.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class CandlesConfig:
+    """Configuration for a candles feed instance.
+
+    :param connector_name: Exchange identifier (e.g., "binance_spot")
+    :param trading_pair: Trading pair in standard format (e.g., "BTC-USDT")
+    :param interval: Candle interval string (e.g., "1m", "5m", "1h")
+    :param max_records: Maximum number of candles to store
+    """
+
+    connector_name: str
+    trading_pair: str
+    interval: str = "1m"
+    max_records: int = 500
+
+
+@dataclass
+class HistoricalCandlesConfig:
+    """Configuration for fetching historical candles.
+
+    :param connector_name: Exchange identifier
+    :param trading_pair: Trading pair in standard format
+    :param interval: Candle interval string
+    :param start_time: Start timestamp in seconds
+    :param end_time: End timestamp in seconds
+    """
+
+    connector_name: str
+    trading_pair: str
+    interval: str
+    start_time: int
+    end_time: int
+
+
+class UnsupportedConnectorException(Exception):
+    """Raised when a requested exchange connector is not supported.
+
+    :param connector_name: The unsupported connector name
+    """
+
+    def __init__(self, connector_name: str) -> None:
+        super().__init__(f"Connector '{connector_name}' is not supported.")
+        self.connector_name = connector_name

--- a/candles_feed/hb_compat/data_types.py
+++ b/candles_feed/hb_compat/data_types.py
@@ -1,0 +1,29 @@
+"""Data types matching hummingbot's interface for candles configuration.
+
+These types mirror hummingbot's HistoricalCandlesConfig to allow drop-in
+compatibility without requiring hummingbot as a dependency.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class HistoricalCandlesConfig:
+    """Configuration for fetching historical candles.
+
+    Mirrors hummingbot's HistoricalCandlesConfig for drop-in compatibility.
+
+    :param connector_name: Exchange connector identifier (e.g., 'binance').
+    :param trading_pair: Trading pair in standard format (e.g., 'BTC-USDT').
+    :param interval: Candle interval string (e.g., '1m', '5m', '1h').
+    :param start_time: Start timestamp in seconds (Unix epoch).
+    :param end_time: End timestamp in seconds (Unix epoch).
+    :param max_records: Maximum number of candle records to return.
+    """
+
+    connector_name: str
+    trading_pair: str
+    interval: str
+    start_time: int = 0
+    end_time: int = 0
+    max_records: int = 500

--- a/candles_feed/hb_compat/data_types.py
+++ b/candles_feed/hb_compat/data_types.py
@@ -26,7 +26,7 @@ class HistoricalCandlesConfig(BaseModel):
     end_time: int
 
 
-class UnsupportedConnectorException(Exception):
+class UnsupportedConnectorError(Exception):
     """Raised when a connector is not supported by hb-candles-feed."""
 
     def __init__(self, connector: str):

--- a/candles_feed/hb_compat/factory.py
+++ b/candles_feed/hb_compat/factory.py
@@ -1,0 +1,56 @@
+"""CandlesFactory — drop-in replacement for hummingbot's CandlesFactory.
+
+Maps hummingbot connector names to CandlesBaseAdapter instances. Handles the
+name mapping between hummingbot names (e.g., "binance") and ExchangeRegistry
+keys (e.g., "binance_spot").
+"""
+
+from candles_feed.hb_compat.adapter import CandlesBaseAdapter
+from candles_feed.hb_compat.data_types import CandlesConfig, UnsupportedConnectorException
+
+
+class CandlesFactory:
+    """Factory creating CandlesBaseAdapter instances from CandlesConfig.
+
+    Intentionally hardcoded mapping — only explicitly tested exchanges are exposed.
+    When new adapters are added and validated, add them to _CONNECTOR_MAP.
+    """
+
+    # Maps hummingbot connector names → ExchangeRegistry keys.
+    # Hummingbot uses "binance" for spot; registry uses "binance_spot".
+    # Perpetual names match directly (e.g., "binance_perpetual").
+    _CONNECTOR_MAP: dict[str, str] = {
+        "binance": "binance_spot",
+        "binance_perpetual": "binance_perpetual",
+        "bybit": "bybit_spot",
+        "coinbase_advanced_trade": "coinbase_advanced_trade",
+        "kraken": "kraken_spot",
+        "kucoin": "kucoin_spot",
+        "okx": "okx_spot",
+    }
+
+    @classmethod
+    def get_candle(cls, candles_config: CandlesConfig) -> CandlesBaseAdapter:
+        """Create a candle feed adapter from config.
+
+        :param candles_config: Configuration matching hummingbot's CandlesConfig
+        :return: CandlesBaseAdapter instance
+        :raises UnsupportedConnectorException: If connector is not supported
+        """
+        registry_key = cls._CONNECTOR_MAP.get(candles_config.connector)
+        if registry_key is None:
+            raise UnsupportedConnectorException(candles_config.connector)
+        return CandlesBaseAdapter(
+            exchange=registry_key,
+            trading_pair=candles_config.trading_pair,
+            interval=candles_config.interval,
+            max_records=candles_config.max_records,
+        )
+
+    @classmethod
+    def get_supported_connectors(cls) -> set[str]:
+        """Return set of supported hummingbot connector names.
+
+        :return: Copy of supported connectors set (hummingbot names, not registry keys)
+        """
+        return set(cls._CONNECTOR_MAP.keys())

--- a/candles_feed/hb_compat/factory.py
+++ b/candles_feed/hb_compat/factory.py
@@ -6,7 +6,7 @@ keys (e.g., "binance_spot").
 """
 
 from candles_feed.hb_compat.adapter import CandlesBaseAdapter
-from candles_feed.hb_compat.data_types import CandlesConfig, UnsupportedConnectorException
+from candles_feed.hb_compat.data_types import CandlesConfig, UnsupportedConnectorError
 
 
 class CandlesFactory:
@@ -35,11 +35,11 @@ class CandlesFactory:
 
         :param candles_config: Configuration matching hummingbot's CandlesConfig
         :return: CandlesBaseAdapter instance
-        :raises UnsupportedConnectorException: If connector is not supported
+        :raises UnsupportedConnectorError: If connector is not supported
         """
         registry_key = cls._CONNECTOR_MAP.get(candles_config.connector)
         if registry_key is None:
-            raise UnsupportedConnectorException(candles_config.connector)
+            raise UnsupportedConnectorError(candles_config.connector)
         return CandlesBaseAdapter(
             exchange=registry_key,
             trading_pair=candles_config.trading_pair,

--- a/candles_feed/hb_compat/protocols.py
+++ b/candles_feed/hb_compat/protocols.py
@@ -1,0 +1,78 @@
+"""Protocol definitions for the hummingbot compatibility layer.
+
+Defines structural subtypes (Protocols) that match hummingbot's candles
+connector interface, enabling static type checking without hummingbot imports.
+"""
+
+from typing import Protocol, runtime_checkable
+
+import numpy as np
+import pandas as pd
+
+from candles_feed.hb_compat.data_types import HistoricalCandlesConfig
+
+
+@runtime_checkable
+class CandlesBaseProtocol(Protocol):
+    """Structural interface matching hummingbot's CandlesBase.
+
+    Any object with these properties/methods satisfies this protocol
+    without needing to inherit from it.
+    """
+
+    @property
+    def name(self) -> str:
+        """Exchange identifier."""
+        ...
+
+    @property
+    def interval(self) -> str:
+        """Candle interval string."""
+        ...
+
+    @property
+    def max_records(self) -> int:
+        """Maximum candle count."""
+        ...
+
+    @property
+    def ready(self) -> bool:
+        """True when the candle history is full."""
+        ...
+
+    @property
+    def candles_df(self) -> pd.DataFrame:
+        """OHLCV candle data as a DataFrame."""
+        ...
+
+    @property
+    def interval_in_seconds(self) -> int:
+        """Interval duration in seconds."""
+        ...
+
+    def start(self) -> None:
+        """Start the candles feed."""
+        ...
+
+    def stop(self) -> None:
+        """Stop the candles feed."""
+        ...
+
+    async def fetch_candles(
+        self,
+        start_time: int | None = None,
+        end_time: int | None = None,
+        limit: int | None = None,
+    ) -> np.ndarray:
+        """Fetch candles as a numpy array."""
+        ...
+
+    async def get_historical_candles(
+        self, config: HistoricalCandlesConfig
+    ) -> pd.DataFrame:
+        """Get historical candles from config."""
+        ...
+
+    def get_exchange_trading_pair(self, trading_pair: str) -> str:
+        """Return exchange-formatted trading pair."""
+        ...

--- a/candles_feed/hb_compat/protocols.py
+++ b/candles_feed/hb_compat/protocols.py
@@ -1,0 +1,76 @@
+"""Protocol defining hummingbot's expected CandlesBase interface.
+
+This protocol captures what MarketDataProvider actually calls on candle feed objects.
+"""
+
+from typing import Protocol, runtime_checkable
+
+import numpy as np
+import pandas as pd
+
+from candles_feed.hb_compat.data_types import HistoricalCandlesConfig
+
+
+@runtime_checkable
+class CandlesBaseProtocol(Protocol):
+    """Interface contract that hummingbot's MarketDataProvider expects.
+
+    Only includes methods and properties that MarketDataProvider actually uses.
+    """
+
+    @property
+    def name(self) -> str:
+        """Exchange identifier."""
+        ...
+
+    @property
+    def interval(self) -> str:
+        """Candle interval (e.g., '1m', '5m')."""
+        ...
+
+    @property
+    def max_records(self) -> int:
+        """Maximum number of candles stored."""
+        ...
+
+    @property
+    def ready(self) -> bool:
+        """True when candle deque is full."""
+        ...
+
+    @property
+    def candles_df(self) -> pd.DataFrame:
+        """OHLCV data as a DataFrame."""
+        ...
+
+    @property
+    def interval_in_seconds(self) -> int:
+        """Interval duration in seconds."""
+        ...
+
+    def start(self) -> None:
+        """Start the candle feed (synchronous)."""
+        ...
+
+    def stop(self) -> None:
+        """Stop the candle feed (synchronous)."""
+        ...
+
+    async def fetch_candles(
+        self,
+        start_time: int | None = None,
+        end_time: int | None = None,
+        limit: int | None = None,
+    ) -> np.ndarray:
+        """Fetch candles as numpy array."""
+        ...
+
+    async def get_historical_candles(
+        self, config: HistoricalCandlesConfig
+    ) -> pd.DataFrame:
+        """Get historical candles using config object."""
+        ...
+
+    def get_exchange_trading_pair(self, trading_pair: str) -> str:
+        """Get exchange-specific trading pair format."""
+        ...

--- a/candles_feed/hb_compat/protocols.py
+++ b/candles_feed/hb_compat/protocols.py
@@ -1,0 +1,77 @@
+# candles_feed/hb_compat/protocols.py
+"""Protocol defining hummingbot's expected CandlesBase interface.
+
+This protocol captures what MarketDataProvider actually calls on candle feed objects.
+"""
+
+from typing import Protocol, runtime_checkable
+
+import numpy as np
+import pandas as pd
+
+from candles_feed.hb_compat.data_types import HistoricalCandlesConfig
+
+
+@runtime_checkable
+class CandlesBaseProtocol(Protocol):
+    """Interface contract that hummingbot's MarketDataProvider expects.
+
+    Only includes methods and properties that MarketDataProvider actually uses.
+    """
+
+    @property
+    def name(self) -> str:
+        """Exchange identifier."""
+        ...
+
+    @property
+    def interval(self) -> str:
+        """Candle interval (e.g., '1m', '5m')."""
+        ...
+
+    @property
+    def max_records(self) -> int:
+        """Maximum number of candles stored."""
+        ...
+
+    @property
+    def ready(self) -> bool:
+        """True when candle deque is full."""
+        ...
+
+    @property
+    def candles_df(self) -> pd.DataFrame:
+        """OHLCV data as a DataFrame."""
+        ...
+
+    @property
+    def interval_in_seconds(self) -> int:
+        """Interval duration in seconds."""
+        ...
+
+    def start(self) -> None:
+        """Start the candle feed (synchronous)."""
+        ...
+
+    def stop(self) -> None:
+        """Stop the candle feed (synchronous)."""
+        ...
+
+    async def fetch_candles(
+        self,
+        start_time: int | None = None,
+        end_time: int | None = None,
+        limit: int | None = None,
+    ) -> np.ndarray:
+        """Fetch candles as numpy array."""
+        ...
+
+    async def get_historical_candles(
+        self, config: HistoricalCandlesConfig
+    ) -> pd.DataFrame:
+        """Get historical candles using config object."""
+        ...
+
+    def get_exchange_trading_pair(self, trading_pair: str) -> str:
+        """Get exchange-specific trading pair format."""
+        ...

--- a/docs/hummingbot-fork-integration.md
+++ b/docs/hummingbot-fork-integration.md
@@ -1,0 +1,168 @@
+# Hummingbot Fork Integration Guide
+
+This guide explains how to integrate `hb-candles-feed` as a drop-in replacement for
+hummingbot's built-in candles subsystem.
+
+## Prerequisites
+
+- A fork of [hummingbot/hummingbot](https://github.com/hummingbot/hummingbot)
+- `hb-candles-feed` installed (see Installation below)
+
+## Installation
+
+Install `hb-candles-feed` as an editable dependency in your hummingbot environment:
+
+```bash
+# From your hummingbot fork root
+pip install -e /path/to/candles-feed
+```
+
+Or add to your `setup.py` / `pyproject.toml` dependencies:
+
+```
+candles-feed @ git+https://github.com/MementoRC/hb-candles-feed.git@main
+```
+
+## File Changes
+
+Three files need modification in your hummingbot fork.
+
+### 1. `hummingbot/data_feed/candles_feed/candles_factory.py`
+
+**Before:**
+```python
+from hummingbot.data_feed.candles_feed.binance_perpetual_candles import BinancePerpetualCandles
+from hummingbot.data_feed.candles_feed.binance_spot_candles import BinanceSpotCandles
+# ... many more imports ...
+
+class CandlesFactory:
+    _candles_map = {
+        "binance": BinanceSpotCandles,
+        "binance_perpetual": BinancePerpetualCandles,
+        # ... many more entries ...
+    }
+
+    @classmethod
+    def get_candle(cls, candles_config: CandlesConfig):
+        # ... complex instantiation logic ...
+```
+
+**After:**
+```python
+from candles_feed.hb_compat import CandlesFactory as HBCandlesFactory, CandlesConfig
+
+# Re-export for backward compatibility
+CandlesFactory = HBCandlesFactory
+```
+
+### 2. `hummingbot/data_feed/candles_feed/data_types.py`
+
+**Before:**
+```python
+from dataclasses import dataclass
+
+@dataclass
+class CandlesConfig:
+    connector: str
+    trading_pair: str
+    interval: str = "1m"
+    max_records: int = 500
+
+# ... other types ...
+```
+
+**After:**
+```python
+from candles_feed.hb_compat import (
+    CandlesConfig,
+    HistoricalCandlesConfig,
+    UnsupportedConnectorException,
+)
+
+# Re-export for backward compatibility — existing imports still work
+__all__ = ["CandlesConfig", "HistoricalCandlesConfig", "UnsupportedConnectorException"]
+```
+
+### 3. `hummingbot/data_feed/market_data_provider.py`
+
+This is the main consumer. Key changes:
+
+**Before (get_historical_candles_df):**
+```python
+async def get_historical_candles_df(self, config: HistoricalCandlesConfig) -> pd.DataFrame:
+    candle_feed = self._candles[candle_key]
+    candle_feed._candles = deque(maxlen=config.max_records)  # Direct deque access
+    candles = await candle_feed.fetch_candles(...)
+    candle_feed._candles.extend(candles)
+    return candle_feed.candles_df
+```
+
+**After:**
+```python
+async def get_historical_candles_df(self, config: HistoricalCandlesConfig) -> pd.DataFrame:
+    candle_feed = self._candles[candle_key]
+    df = await candle_feed.get_historical_candles(config)
+    candle_feed.reset_with_dataframe(df)  # Uses adapter method instead of deque access
+    return candle_feed.candles_df
+```
+
+## Legacy Fallback Pattern
+
+For exchanges not yet supported by `hb-candles-feed`, use a fallback pattern:
+
+```python
+from candles_feed.hb_compat import CandlesFactory, CandlesConfig, UnsupportedConnectorException
+
+# Import original factory as fallback
+from hummingbot.data_feed.candles_feed._original_candles_factory import OriginalCandlesFactory
+
+class HybridCandlesFactory:
+    @classmethod
+    def get_candle(cls, config: CandlesConfig):
+        try:
+            return CandlesFactory.get_candle(config)
+        except UnsupportedConnectorException:
+            # Fall back to hummingbot's built-in implementation
+            return OriginalCandlesFactory.get_candle(config)
+```
+
+### Supported Connectors
+
+| Connector | Status |
+|-----------|--------|
+| `binance` (spot) | Supported |
+| `binance_perpetual` | Supported |
+| `bybit` (spot) | Supported |
+| `coinbase_advanced_trade` | Supported |
+| `kraken` (spot) | Supported |
+| `kucoin` (spot) | Supported |
+| `okx` (spot) | Supported |
+
+## Testing
+
+### Verify installation
+
+```python
+python -c "from candles_feed.hb_compat import CandlesFactory; print('OK')"
+```
+
+### Verify connector mapping
+
+```python
+from candles_feed.hb_compat import CandlesFactory, CandlesConfig
+
+config = CandlesConfig(connector="binance", trading_pair="BTC-USDT", interval="1m")
+candle = CandlesFactory.get_candle(config)
+print(f"Name: {candle.name}")           # binance_spot
+print(f"Interval: {candle.interval}")    # 1m
+print(f"Ready: {candle.ready}")          # False (no data yet)
+```
+
+### Run hummingbot's existing candle tests
+
+After making the file changes above, run hummingbot's test suite to verify
+backward compatibility:
+
+```bash
+pytest tests/hummingbot/data_feed/candles_feed/ -v
+```

--- a/docs/hummingbot-fork-integration.md
+++ b/docs/hummingbot-fork-integration.md
@@ -76,11 +76,11 @@ class CandlesConfig:
 from candles_feed.hb_compat import (
     CandlesConfig,
     HistoricalCandlesConfig,
-    UnsupportedConnectorException,
+    UnsupportedConnectorError,
 )
 
 # Re-export for backward compatibility — existing imports still work
-__all__ = ["CandlesConfig", "HistoricalCandlesConfig", "UnsupportedConnectorException"]
+__all__ = ["CandlesConfig", "HistoricalCandlesConfig", "UnsupportedConnectorError"]
 ```
 
 ### 3. `hummingbot/data_feed/market_data_provider.py`
@@ -111,7 +111,7 @@ async def get_historical_candles_df(self, config: HistoricalCandlesConfig) -> pd
 For exchanges not yet supported by `hb-candles-feed`, use a fallback pattern:
 
 ```python
-from candles_feed.hb_compat import CandlesFactory, CandlesConfig, UnsupportedConnectorException
+from candles_feed.hb_compat import CandlesFactory, CandlesConfig, UnsupportedConnectorError
 
 # Import original factory as fallback
 from hummingbot.data_feed.candles_feed._original_candles_factory import OriginalCandlesFactory
@@ -121,7 +121,7 @@ class HybridCandlesFactory:
     def get_candle(cls, config: CandlesConfig):
         try:
             return CandlesFactory.get_candle(config)
-        except UnsupportedConnectorException:
+        except UnsupportedConnectorError:
             # Fall back to hummingbot's built-in implementation
             return OriginalCandlesFactory.get_candle(config)
 ```

--- a/tests/unit/core/test_candles_feed.py
+++ b/tests/unit/core/test_candles_feed.py
@@ -336,6 +336,13 @@ class TestCandlesFeed:
         assert len(candles_feed._candles) == 1
         assert candles_feed._candles[0].timestamp == base_time
 
+    def test_clear_candles(self, candles_feed, sample_candle_data):
+        """clear_candles removes all candles from the feed."""
+        candles_feed.add_candle(sample_candle_data)
+        assert len(candles_feed.get_candles()) == 1
+        candles_feed.clear_candles()
+        assert len(candles_feed.get_candles()) == 0
+
     def test_interval_in_seconds_property(self, mock_exchange_registry):
         """interval_in_seconds delegates to the adapter's supported intervals map."""
         feed = CandlesFeed(exchange="binance_spot", trading_pair="BTC-USDT", interval="1m")

--- a/tests/unit/core/test_candles_feed.py
+++ b/tests/unit/core/test_candles_feed.py
@@ -337,7 +337,7 @@ class TestCandlesFeed:
         assert candles_feed._candles[0].timestamp == base_time
 
     def test_interval_in_seconds_property(self, mock_exchange_registry):
-        """interval_in_seconds exposes the interval duration without accessing _adapter."""
+        """interval_in_seconds delegates to the adapter's supported intervals map."""
         feed = CandlesFeed(exchange="binance_spot", trading_pair="BTC-USDT", interval="1m")
         assert feed.interval_in_seconds == 60
 

--- a/tests/unit/core/test_candles_feed.py
+++ b/tests/unit/core/test_candles_feed.py
@@ -336,6 +336,14 @@ class TestCandlesFeed:
         assert len(candles_feed._candles) == 1
         assert candles_feed._candles[0].timestamp == base_time
 
+    def test_interval_in_seconds_property(self, mock_exchange_registry):
+        """interval_in_seconds exposes the interval duration without accessing _adapter."""
+        feed = CandlesFeed(exchange="binance_spot", trading_pair="BTC-USDT", interval="1m")
+        assert feed.interval_in_seconds == 60
+
+        feed_5m = CandlesFeed(exchange="binance_spot", trading_pair="BTC-USDT", interval="5m")
+        assert feed_5m.interval_in_seconds == 300
+
     @pytest.mark.asyncio
     async def test_max_records_limit(self, candles_feed):
         """Test the max records limit is enforced."""

--- a/tests/unit/hb_compat/conftest.py
+++ b/tests/unit/hb_compat/conftest.py
@@ -1,0 +1,37 @@
+"""Shared fixtures for hb_compat tests."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from candles_feed.adapters.base_adapter import BaseAdapter
+from candles_feed.core.exchange_registry import ExchangeRegistry
+
+
+@pytest.fixture(autouse=True)
+def mock_exchange_registry():
+    """Mock ExchangeRegistry for all hb_compat tests.
+
+    CandlesFeed.__init__ calls ExchangeRegistry.get_adapter_instance() immediately,
+    so this must be mocked before any CandlesBaseAdapter is constructed.
+    """
+    with patch.object(ExchangeRegistry, "get_adapter_instance") as mock:
+        mock_adapter = MagicMock(spec=BaseAdapter)
+        mock_adapter.get_trading_pair_format.return_value = "BTCUSDT"
+        mock_adapter.get_supported_intervals.return_value = {
+            "1m": 60, "5m": 300, "15m": 900, "1h": 3600,
+        }
+        mock_adapter.get_ws_supported_intervals.return_value = ["1m", "5m", "1h"]
+        mock.return_value = mock_adapter
+        yield mock
+
+
+@pytest.fixture(autouse=True)
+def mock_network_client_factory():
+    """Mock NetworkClientFactory to prevent real network client creation."""
+    with patch(
+        "candles_feed.core.hummingbot_network_client_adapter.NetworkClientFactory.create_client"
+    ) as mock:
+        mock_client = MagicMock()
+        mock.return_value = mock_client
+        yield mock

--- a/tests/unit/hb_compat/test_adapter.py
+++ b/tests/unit/hb_compat/test_adapter.py
@@ -1,0 +1,233 @@
+"""Tests for CandlesBaseAdapter — the core translation layer."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from candles_feed.core.candle_data import CandleData
+
+
+def _make_candle(ts: int, price: float = 100.0) -> CandleData:
+    """Helper to create a CandleData with minimal fields."""
+    return CandleData(
+        timestamp_raw=ts,
+        open=price,
+        high=price + 1,
+        low=price - 1,
+        close=price + 0.5,
+        volume=1000.0,
+        quote_asset_volume=100000.0,
+        n_trades=50,
+        taker_buy_base_volume=500.0,
+        taker_buy_quote_volume=50000.0,
+    )
+
+
+class TestCandlesBaseAdapterProperties:
+    """Test property delegation to CandlesFeed."""
+
+    def test_name_returns_exchange(self):
+        from candles_feed.hb_compat.adapter import CandlesBaseAdapter
+        adapter = CandlesBaseAdapter(
+            exchange="binance", trading_pair="BTC-USDT", interval="1m"
+        )
+        assert adapter.name == "binance"
+
+    def test_interval_delegation(self):
+        from candles_feed.hb_compat.adapter import CandlesBaseAdapter
+        adapter = CandlesBaseAdapter(
+            exchange="binance", trading_pair="BTC-USDT", interval="5m"
+        )
+        assert adapter.interval == "5m"
+
+    def test_max_records_delegation(self):
+        from candles_feed.hb_compat.adapter import CandlesBaseAdapter
+        adapter = CandlesBaseAdapter(
+            exchange="binance", trading_pair="BTC-USDT", max_records=1000
+        )
+        assert adapter.max_records == 1000
+
+    def test_ready_delegation(self):
+        from candles_feed.hb_compat.adapter import CandlesBaseAdapter
+        adapter = CandlesBaseAdapter(
+            exchange="binance", trading_pair="BTC-USDT", max_records=2
+        )
+        assert adapter.ready is False
+        adapter._feed.add_candle(_make_candle(1000))
+        adapter._feed.add_candle(_make_candle(1060))
+        assert adapter.ready is True
+
+    def test_candles_df_is_property_not_method(self):
+        from candles_feed.hb_compat.adapter import CandlesBaseAdapter
+        adapter = CandlesBaseAdapter(
+            exchange="binance", trading_pair="BTC-USDT"
+        )
+        df = adapter.candles_df
+        assert isinstance(df, pd.DataFrame)
+
+    def test_candles_df_has_correct_columns(self):
+        from candles_feed.hb_compat.adapter import CandlesBaseAdapter
+        adapter = CandlesBaseAdapter(
+            exchange="binance", trading_pair="BTC-USDT", max_records=2
+        )
+        adapter._feed.add_candle(_make_candle(1000))
+        df = adapter.candles_df
+        expected_columns = [
+            "timestamp", "open", "high", "low", "close", "volume",
+            "quote_asset_volume", "n_trades",
+            "taker_buy_base_volume", "taker_buy_quote_volume",
+        ]
+        assert list(df.columns) == expected_columns
+
+    def test_interval_in_seconds(self):
+        from candles_feed.hb_compat.adapter import CandlesBaseAdapter
+        adapter = CandlesBaseAdapter(
+            exchange="binance", trading_pair="BTC-USDT", interval="1m"
+        )
+        assert adapter.interval_in_seconds == 60
+
+    def test_get_exchange_trading_pair(self):
+        from candles_feed.hb_compat.adapter import CandlesBaseAdapter
+        adapter = CandlesBaseAdapter(
+            exchange="binance", trading_pair="BTC-USDT"
+        )
+        result = adapter.get_exchange_trading_pair("BTC-USDT")
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+
+class TestCandlesBaseAdapterProtocolConformance:
+    """Verify adapter satisfies CandlesBaseProtocol."""
+
+    def test_isinstance_check(self):
+        from candles_feed.hb_compat.adapter import CandlesBaseAdapter
+        from candles_feed.hb_compat.protocols import CandlesBaseProtocol
+        adapter = CandlesBaseAdapter(
+            exchange="binance", trading_pair="BTC-USDT"
+        )
+        assert isinstance(adapter, CandlesBaseProtocol)
+
+
+class TestCandlesBaseAdapterLifecycle:
+    """Test sync start/stop bridge."""
+
+    @pytest.mark.asyncio
+    async def test_start_schedules_async_task(self):
+        from candles_feed.hb_compat.adapter import CandlesBaseAdapter
+        adapter = CandlesBaseAdapter(
+            exchange="binance", trading_pair="BTC-USDT"
+        )
+        with patch.object(adapter._feed, "start", new_callable=AsyncMock) as mock_start:
+            adapter.start()
+            import asyncio
+            await asyncio.sleep(0.1)
+            mock_start.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_stop_schedules_async_task(self):
+        from candles_feed.hb_compat.adapter import CandlesBaseAdapter
+        adapter = CandlesBaseAdapter(
+            exchange="binance", trading_pair="BTC-USDT"
+        )
+        with patch.object(adapter._feed, "stop", new_callable=AsyncMock) as mock_stop:
+            adapter.stop()
+            import asyncio
+            await asyncio.sleep(0.1)
+            mock_stop.assert_called_once()
+
+
+class TestCandlesBaseAdapterDataConversion:
+    """Test data format conversions."""
+
+    @pytest.mark.asyncio
+    async def test_fetch_candles_returns_ndarray(self):
+        from candles_feed.hb_compat.adapter import CandlesBaseAdapter
+        adapter = CandlesBaseAdapter(
+            exchange="binance", trading_pair="BTC-USDT"
+        )
+        candles = [_make_candle(1000), _make_candle(1060)]
+        with patch.object(
+            adapter._feed, "fetch_candles", new_callable=AsyncMock, return_value=candles
+        ):
+            result = await adapter.fetch_candles(start_time=1000, end_time=1060)
+            assert isinstance(result, np.ndarray)
+            assert result.shape == (2, 10)
+            assert result[0, 0] == 1000
+
+    @pytest.mark.asyncio
+    async def test_fetch_candles_none_limit_defaults_to_500(self):
+        from candles_feed.hb_compat.adapter import CandlesBaseAdapter
+        adapter = CandlesBaseAdapter(
+            exchange="binance", trading_pair="BTC-USDT"
+        )
+        with patch.object(
+            adapter._feed, "fetch_candles", new_callable=AsyncMock, return_value=[]
+        ) as mock_fetch:
+            await adapter.fetch_candles(limit=None)
+            mock_fetch.assert_called_once_with(
+                start_time=None, end_time=None, limit=500
+            )
+
+    @pytest.mark.asyncio
+    async def test_get_historical_candles_unpacks_config(self):
+        from candles_feed.hb_compat.adapter import CandlesBaseAdapter
+        from candles_feed.hb_compat.data_types import HistoricalCandlesConfig
+        adapter = CandlesBaseAdapter(
+            exchange="binance", trading_pair="BTC-USDT"
+        )
+        config = HistoricalCandlesConfig(
+            connector_name="binance",
+            trading_pair="BTC-USDT",
+            interval="1m",
+            start_time=1000,
+            end_time=2000,
+        )
+        mock_df = pd.DataFrame({"timestamp": [1000]})
+        with patch.object(
+            adapter._feed,
+            "get_historical_candles",
+            new_callable=AsyncMock,
+            return_value=mock_df,
+        ) as mock_hist:
+            result = await adapter.get_historical_candles(config)
+            mock_hist.assert_called_once_with(start_time=1000, end_time=2000)
+            assert isinstance(result, pd.DataFrame)
+
+
+class TestCandlesBaseAdapterResetWithDataFrame:
+    """Test reset_with_dataframe for MarketDataProvider compatibility."""
+
+    def test_reset_clears_and_repopulates(self):
+        from candles_feed.hb_compat.adapter import CandlesBaseAdapter
+        adapter = CandlesBaseAdapter(
+            exchange="binance", trading_pair="BTC-USDT", max_records=10
+        )
+        adapter._feed.add_candle(_make_candle(500))
+        assert len(adapter._feed.get_candles()) == 1
+
+        df = pd.DataFrame([
+            [1000, 100.0, 101.0, 99.0, 100.5, 1000.0, 100000.0, 50, 500.0, 50000.0],
+            [1060, 101.0, 102.0, 100.0, 101.5, 1100.0, 110000.0, 55, 550.0, 55000.0],
+        ], columns=[
+            "timestamp", "open", "high", "low", "close", "volume",
+            "quote_asset_volume", "n_trades",
+            "taker_buy_base_volume", "taker_buy_quote_volume",
+        ])
+        adapter.reset_with_dataframe(df)
+
+        candles = adapter._feed.get_candles()
+        assert len(candles) == 2
+        assert candles[0].timestamp == 1000
+        assert candles[1].timestamp == 1060
+
+    def test_reset_with_empty_dataframe(self):
+        from candles_feed.hb_compat.adapter import CandlesBaseAdapter
+        adapter = CandlesBaseAdapter(
+            exchange="binance", trading_pair="BTC-USDT"
+        )
+        adapter._feed.add_candle(_make_candle(500))
+
+        adapter.reset_with_dataframe(pd.DataFrame())
+        assert len(adapter._feed.get_candles()) == 0

--- a/tests/unit/hb_compat/test_adapter.py
+++ b/tests/unit/hb_compat/test_adapter.py
@@ -195,6 +195,19 @@ class TestCandlesBaseAdapterDataConversion:
             mock_hist.assert_called_once_with(start_time=1000, end_time=2000)
             assert isinstance(result, pd.DataFrame)
 
+    @pytest.mark.asyncio
+    async def test_fetch_candles_empty_returns_empty_ndarray(self):
+        from candles_feed.hb_compat.adapter import CandlesBaseAdapter
+        adapter = CandlesBaseAdapter(
+            exchange="binance", trading_pair="BTC-USDT"
+        )
+        with patch.object(
+            adapter._feed, "fetch_candles", new_callable=AsyncMock, return_value=[]
+        ):
+            result = await adapter.fetch_candles(start_time=1000, end_time=1060)
+            assert isinstance(result, np.ndarray)
+            assert result.shape == (0, 10)
+
 
 class TestCandlesBaseAdapterResetWithDataFrame:
     """Test reset_with_dataframe for MarketDataProvider compatibility."""
@@ -221,6 +234,12 @@ class TestCandlesBaseAdapterResetWithDataFrame:
         assert len(candles) == 2
         assert candles[0].timestamp == 1000
         assert candles[1].timestamp == 1060
+        assert candles[0].open == 100.0
+        assert candles[0].close == 100.5
+        assert candles[0].volume == 1000.0
+        assert candles[1].open == 101.0
+        assert candles[1].close == 101.5
+        assert candles[1].volume == 1100.0
 
     def test_reset_with_empty_dataframe(self):
         from candles_feed.hb_compat.adapter import CandlesBaseAdapter

--- a/tests/unit/hb_compat/test_data_types.py
+++ b/tests/unit/hb_compat/test_data_types.py
@@ -58,17 +58,17 @@ class TestHistoricalCandlesConfig:
             HistoricalCandlesConfig(connector_name="binance", trading_pair="BTC-USDT")
 
 
-class TestUnsupportedConnectorException:
-    """UnsupportedConnectorException must include connector name in message."""
+class TestUnsupportedConnectorError:
+    """UnsupportedConnectorError must include connector name in message."""
 
     def test_message_includes_connector(self):
-        from candles_feed.hb_compat.data_types import UnsupportedConnectorException
-        exc = UnsupportedConnectorException("dydx")
+        from candles_feed.hb_compat.data_types import UnsupportedConnectorError
+        exc = UnsupportedConnectorError("dydx")
         assert "dydx" in str(exc)
 
     def test_is_exception(self):
-        from candles_feed.hb_compat.data_types import UnsupportedConnectorException
-        assert issubclass(UnsupportedConnectorException, Exception)
+        from candles_feed.hb_compat.data_types import UnsupportedConnectorError
+        assert issubclass(UnsupportedConnectorError, Exception)
 
 
 class TestPublicAPI:
@@ -81,11 +81,11 @@ class TestPublicAPI:
             CandlesConfig,
             CandlesFactory,
             HistoricalCandlesConfig,
-            UnsupportedConnectorException,
+            UnsupportedConnectorError,
         )
         assert CandlesBaseAdapter is not None
         assert CandlesBaseProtocol is not None
         assert CandlesConfig is not None
         assert CandlesFactory is not None
         assert HistoricalCandlesConfig is not None
-        assert UnsupportedConnectorException is not None
+        assert UnsupportedConnectorError is not None

--- a/tests/unit/hb_compat/test_data_types.py
+++ b/tests/unit/hb_compat/test_data_types.py
@@ -1,0 +1,71 @@
+"""Tests for hb_compat data types matching hummingbot's interface."""
+
+import pytest
+from pydantic import ValidationError
+
+
+class TestCandlesConfig:
+    """CandlesConfig must match hummingbot's field names, types, and defaults."""
+
+    def test_required_fields(self):
+        from candles_feed.hb_compat.data_types import CandlesConfig
+        config = CandlesConfig(connector="binance", trading_pair="BTC-USDT")
+        assert config.connector == "binance"
+        assert config.trading_pair == "BTC-USDT"
+
+    def test_defaults(self):
+        from candles_feed.hb_compat.data_types import CandlesConfig
+        config = CandlesConfig(connector="binance", trading_pair="BTC-USDT")
+        assert config.interval == "1m"
+        assert config.max_records == 500
+
+    def test_custom_values(self):
+        from candles_feed.hb_compat.data_types import CandlesConfig
+        config = CandlesConfig(
+            connector="okx", trading_pair="ETH-USDT", interval="5m", max_records=1000
+        )
+        assert config.connector == "okx"
+        assert config.interval == "5m"
+        assert config.max_records == 1000
+
+    def test_missing_required_raises(self):
+        from candles_feed.hb_compat.data_types import CandlesConfig
+        with pytest.raises(ValidationError):
+            CandlesConfig(connector="binance")  # missing trading_pair
+
+
+class TestHistoricalCandlesConfig:
+    """HistoricalCandlesConfig must match hummingbot's fields exactly."""
+
+    def test_all_fields(self):
+        from candles_feed.hb_compat.data_types import HistoricalCandlesConfig
+        config = HistoricalCandlesConfig(
+            connector_name="binance",
+            trading_pair="BTC-USDT",
+            interval="1m",
+            start_time=1000000,
+            end_time=2000000,
+        )
+        assert config.connector_name == "binance"
+        assert config.trading_pair == "BTC-USDT"
+        assert config.interval == "1m"
+        assert config.start_time == 1000000
+        assert config.end_time == 2000000
+
+    def test_all_fields_required(self):
+        from candles_feed.hb_compat.data_types import HistoricalCandlesConfig
+        with pytest.raises(ValidationError):
+            HistoricalCandlesConfig(connector_name="binance", trading_pair="BTC-USDT")
+
+
+class TestUnsupportedConnectorException:
+    """UnsupportedConnectorException must include connector name in message."""
+
+    def test_message_includes_connector(self):
+        from candles_feed.hb_compat.data_types import UnsupportedConnectorException
+        exc = UnsupportedConnectorException("dydx")
+        assert "dydx" in str(exc)
+
+    def test_is_exception(self):
+        from candles_feed.hb_compat.data_types import UnsupportedConnectorException
+        assert issubclass(UnsupportedConnectorException, Exception)

--- a/tests/unit/hb_compat/test_data_types.py
+++ b/tests/unit/hb_compat/test_data_types.py
@@ -69,3 +69,23 @@ class TestUnsupportedConnectorException:
     def test_is_exception(self):
         from candles_feed.hb_compat.data_types import UnsupportedConnectorException
         assert issubclass(UnsupportedConnectorException, Exception)
+
+
+class TestPublicAPI:
+    """All public symbols must be importable from candles_feed.hb_compat."""
+
+    def test_import_all_public_symbols(self):
+        from candles_feed.hb_compat import (
+            CandlesBaseAdapter,
+            CandlesBaseProtocol,
+            CandlesConfig,
+            CandlesFactory,
+            HistoricalCandlesConfig,
+            UnsupportedConnectorException,
+        )
+        assert CandlesBaseAdapter is not None
+        assert CandlesBaseProtocol is not None
+        assert CandlesConfig is not None
+        assert CandlesFactory is not None
+        assert HistoricalCandlesConfig is not None
+        assert UnsupportedConnectorException is not None

--- a/tests/unit/hb_compat/test_factory.py
+++ b/tests/unit/hb_compat/test_factory.py
@@ -1,0 +1,64 @@
+"""Tests for CandlesFactory — connector routing."""
+
+import pytest
+
+
+class TestCandlesFactory:
+    """CandlesFactory must match hummingbot's get_candle(config) signature."""
+
+    def test_get_candle_returns_adapter(self):
+        from candles_feed.hb_compat.data_types import CandlesConfig
+        from candles_feed.hb_compat.factory import CandlesFactory
+
+        config = CandlesConfig(connector="binance", trading_pair="BTC-USDT")
+        candle = CandlesFactory.get_candle(config)
+
+        from candles_feed.hb_compat.adapter import CandlesBaseAdapter
+        assert isinstance(candle, CandlesBaseAdapter)
+
+    def test_get_candle_passes_config_fields(self):
+        from candles_feed.hb_compat.data_types import CandlesConfig
+        from candles_feed.hb_compat.factory import CandlesFactory
+
+        config = CandlesConfig(
+            connector="binance",
+            trading_pair="ETH-USDT",
+            interval="5m",
+            max_records=1000,
+        )
+        candle = CandlesFactory.get_candle(config)
+        assert candle.name == "binance_spot"  # registry key, not hummingbot name
+        assert candle.interval == "5m"
+        assert candle.max_records == 1000
+
+    def test_unsupported_connector_raises(self):
+        from candles_feed.hb_compat.data_types import (
+            CandlesConfig,
+            UnsupportedConnectorException,
+        )
+        from candles_feed.hb_compat.factory import CandlesFactory
+
+        config = CandlesConfig(connector="dydx", trading_pair="BTC-USDT")
+        with pytest.raises(UnsupportedConnectorException, match="dydx"):
+            CandlesFactory.get_candle(config)
+
+    def test_all_supported_connectors(self):
+        from candles_feed.hb_compat.factory import CandlesFactory
+
+        supported = CandlesFactory.get_supported_connectors()
+        assert "binance" in supported
+        assert "binance_perpetual" in supported
+        assert "bybit" in supported
+        assert "coinbase_advanced_trade" in supported
+        assert "kraken" in supported
+        assert "kucoin" in supported
+        assert "okx" in supported
+        assert len(supported) == 7
+
+    def test_get_supported_connectors_returns_copy(self):
+        from candles_feed.hb_compat.factory import CandlesFactory
+
+        s1 = CandlesFactory.get_supported_connectors()
+        s1.add("fake")
+        s2 = CandlesFactory.get_supported_connectors()
+        assert "fake" not in s2

--- a/tests/unit/hb_compat/test_factory.py
+++ b/tests/unit/hb_compat/test_factory.py
@@ -34,12 +34,12 @@ class TestCandlesFactory:
     def test_unsupported_connector_raises(self):
         from candles_feed.hb_compat.data_types import (
             CandlesConfig,
-            UnsupportedConnectorException,
+            UnsupportedConnectorError,
         )
         from candles_feed.hb_compat.factory import CandlesFactory
 
         config = CandlesConfig(connector="dydx", trading_pair="BTC-USDT")
-        with pytest.raises(UnsupportedConnectorException, match="dydx"):
+        with pytest.raises(UnsupportedConnectorError, match="dydx"):
             CandlesFactory.get_candle(config)
 
     def test_all_supported_connectors(self):

--- a/tests/unit/hb_compat/test_protocols.py
+++ b/tests/unit/hb_compat/test_protocols.py
@@ -1,0 +1,49 @@
+"""Tests for CandlesBaseProtocol definition."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+class TestCandlesBaseProtocol:
+    """Verify the protocol defines the correct interface."""
+
+    def test_protocol_is_importable(self):
+        from candles_feed.hb_compat.protocols import CandlesBaseProtocol
+        assert CandlesBaseProtocol is not None
+
+    def test_protocol_is_runtime_checkable(self):
+        from candles_feed.hb_compat.protocols import CandlesBaseProtocol
+
+        class FakeCandles:
+            name = "test"
+            interval = "1m"
+            max_records = 500
+            ready = True
+            interval_in_seconds = 60
+
+            @property
+            def candles_df(self) -> pd.DataFrame:
+                return pd.DataFrame()
+
+            def start(self) -> None: ...
+            def stop(self) -> None: ...
+
+            async def fetch_candles(self, start_time=None, end_time=None, limit=None) -> np.ndarray:
+                return np.array([])
+
+            async def get_historical_candles(self, config) -> pd.DataFrame:
+                return pd.DataFrame()
+
+            def get_exchange_trading_pair(self, trading_pair: str) -> str:
+                return trading_pair
+
+        assert isinstance(FakeCandles(), CandlesBaseProtocol)
+
+    def test_non_conforming_class_fails(self):
+        from candles_feed.hb_compat.protocols import CandlesBaseProtocol
+
+        class NotCandles:
+            pass
+
+        assert not isinstance(NotCandles(), CandlesBaseProtocol)

--- a/tests/unit/hb_compat/test_protocols.py
+++ b/tests/unit/hb_compat/test_protocols.py
@@ -16,12 +16,17 @@ class TestCandlesBaseProtocol:
         from candles_feed.hb_compat.protocols import CandlesBaseProtocol
 
         class FakeCandles:
-            name = "test"
-            interval = "1m"
-            max_records = 500
-            ready = True
-            interval_in_seconds = 60
-
+            # Python 3.12+ requires @property for Protocol property members
+            @property
+            def name(self) -> str: return "test"
+            @property
+            def interval(self) -> str: return "1m"
+            @property
+            def max_records(self) -> int: return 500
+            @property
+            def ready(self) -> bool: return True
+            @property
+            def interval_in_seconds(self) -> int: return 60
             @property
             def candles_df(self) -> pd.DataFrame:
                 return pd.DataFrame()


### PR DESCRIPTION
## Summary

- Add `candles_feed.hb_compat` package providing drop-in replacements for hummingbot's CandlesFactory, CandlesConfig, CandlesBase, and related classes — no hummingbot import required
- Implement Protocol Adapter pattern: `CandlesBaseProtocol` defines the interface, `CandlesBaseAdapter` wraps `CandlesFeed`, `CandlesFactory` maps 7 connector names (binance, binance_perpetual, bybit, coinbase_advanced_trade, kraken, kucoin, okx)
- Add `interval_in_seconds` property to core `CandlesFeed` class
- Include 33 unit tests covering data types, protocol conformance, adapter delegation, factory routing, and public API
- Add hummingbot fork integration guide documenting the 3 file changes needed

## Test plan

- [x] All 33 hb_compat unit tests pass
- [x] Full existing test suite passes (no regressions)
- [x] Code review: duplicate property removed, docstring corrected
- [ ] Manual: verify import from hummingbot fork (`from candles_feed.hb_compat import CandlesFactory, CandlesConfig`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a Hummingbot-compatible candles API layer and extend the core feed to support interval duration access.

New Features:
- Add an hb_compat package exposing CandlesFactory, CandlesConfig, CandlesBaseAdapter, CandlesBaseProtocol, HistoricalCandlesConfig, and UnsupportedConnectorException as drop-in replacements for Hummingbot's candle interfaces.
- Implement a CandlesBaseAdapter that wraps the core CandlesFeed and provides the Hummingbot CandlesBase-style synchronous lifecycle, data accessors, and type conversions.
- Add a CandlesFactory mapping seven Hummingbot connector names to internal exchange registry keys and constructing configured adapter instances.
- Expose a new interval_in_seconds property on CandlesFeed for convenient access to the configured interval duration.

Enhancements:
- Define a CandlesBaseProtocol protocol capturing the subset of the Hummingbot CandlesBase interface used by MarketDataProvider for runtime type-checkable compatibility.

CI:
- Temporarily disable the cleanup-dev-files GitHub Actions workflow runs until required bot secrets are configured.

Documentation:
- Add a Hummingbot fork integration guide documenting how to replace Hummingbot's native candles implementation with the hb-candles-feed compatibility layer.

Tests:
- Add a dedicated hb_compat test suite covering data types, protocol conformance, adapter behavior, factory routing, public API imports, and interval_in_seconds on the core feed.