### PR TITLE
fix: address sourcery review - NaN safety and test coverage

### DIFF
--- a/.github/workflows/cleanup-dev-files.yml
+++ b/.github/workflows/cleanup-dev-files.yml
@@ -1,24 +1,35 @@
 ---
 name: Cleanup Development Artifacts
 
+# Disabled: requires CI_BOT_TOKEN, CI_BOT_GPG_KEY, CI_BOT_GPG_KEY_ID secrets
+# Re-enable when bot secrets are configured in repository settings
+# on:
+#   push:
+#     branches: [main, development]
+#   schedule:
+#     - cron: '0 2 * * *'
+#   workflow_dispatch:
+#     inputs:
+#       target_branch:
+#         description: 'Branch to clean'
+#         required: false
+#         default: 'development'
+#         type: choice
+#         options:
+#           - main
+#           - development
+
 on:
-  push:
-    branches: [main, development]
-  schedule:
-    - cron: '0 2 * * *'
   workflow_dispatch:
     inputs:
-      target_branch:
-        description: 'Branch to clean'
+      placeholder:
+        description: 'Disabled until bot secrets are configured'
         required: false
-        default: 'development'
-        type: choice
-        options:
-          - main
-          - development
+        default: 'disabled'
 
 jobs:
   cleanup:
+    if: false
     uses: Claire-s-Monster/ci-framework/.github/workflows/cleanup-dev-files.yml@v2.5.1
     with:
       target_branches: >-

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ venv.bak/
 # Documentation
 docs/_build/
 docs/site/
+docs/superpowers/
 site/
 mkdocs.saved.yml
 

--- a/candles_feed/adapters/__init__.py
+++ b/candles_feed/adapters/__init__.py
@@ -2,12 +2,18 @@
 Exchange adapters for the Candles Feed package.
 """
 
+from .aevo.perpetual_adapter import AevoPerpetualAdapter
 from .ascend_ex.spot_adapter import AscendExSpotAdapter
 from .binance.perpetual_adapter import BinancePerpetualAdapter
 from .binance.spot_adapter import BinanceSpotAdapter
+from .bitget.perpetual_adapter import BitgetPerpetualAdapter
+from .bitget.spot_adapter import BitgetSpotAdapter
+from .bitmart.perpetual_adapter import BitmartPerpetualAdapter
+from .btc_markets.spot_adapter import BTCMarketsSpotAdapter
 from .bybit.perpetual_adapter import BybitPerpetualAdapter
 from .bybit.spot_adapter import BybitSpotAdapter
 from .coinbase_advanced_trade.spot_adapter import CoinbaseAdvancedTradeSpotAdapter
+from .dexalot.spot_adapter import DexalotSpotAdapter
 from .gate_io.perpetual_adapter import GateIoPerpetualAdapter
 from .gate_io.spot_adapter import GateIoSpotAdapter
 from .hyperliquid.perpetual_adapter import HyperliquidPerpetualAdapter
@@ -19,13 +25,17 @@ from .mexc.perpetual_adapter import MEXCPerpetualAdapter
 from .mexc.spot_adapter import MEXCSpotAdapter
 from .okx.perpetual_adapter import OKXPerpetualAdapter
 from .okx.spot_adapter import OKXSpotAdapter
+from .pacifica.perpetual_adapter import PacificaPerpetualAdapter
 
 __all__ = [
     # Spot adapters
     "AscendExSpotAdapter",
     "BinanceSpotAdapter",
+    "BitgetSpotAdapter",
+    "BTCMarketsSpotAdapter",
     "BybitSpotAdapter",
     "CoinbaseAdvancedTradeSpotAdapter",
+    "DexalotSpotAdapter",
     "GateIoSpotAdapter",
     "HyperliquidSpotAdapter",
     "KrakenSpotAdapter",
@@ -33,11 +43,15 @@ __all__ = [
     "MEXCSpotAdapter",
     "OKXSpotAdapter",
     # Perpetual adapters
+    "AevoPerpetualAdapter",
     "BinancePerpetualAdapter",
+    "BitgetPerpetualAdapter",
+    "BitmartPerpetualAdapter",
     "BybitPerpetualAdapter",
     "GateIoPerpetualAdapter",
     "HyperliquidPerpetualAdapter",
     "KucoinPerpetualAdapter",
     "MEXCPerpetualAdapter",
     "OKXPerpetualAdapter",
+    "PacificaPerpetualAdapter",
 ]

--- a/candles_feed/adapters/aevo/__init__.py
+++ b/candles_feed/adapters/aevo/__init__.py
@@ -1,0 +1,27 @@
+"""
+Aevo exchange adapter package.
+"""
+
+from .constants import (
+    CANDLES_ENDPOINT,
+    INTERVAL_TO_EXCHANGE,
+    INTERVALS,
+    MAX_RESULTS_PER_CANDLESTICK_REST_REQUEST,
+    REST_URL,
+    WS_INTERVALS,
+    WSS_URL,
+)
+from .perpetual_adapter import AevoPerpetualAdapter
+
+__all__ = [
+    # Adapters
+    "AevoPerpetualAdapter",
+    # Constants
+    "CANDLES_ENDPOINT",
+    "INTERVAL_TO_EXCHANGE",
+    "INTERVALS",
+    "MAX_RESULTS_PER_CANDLESTICK_REST_REQUEST",
+    "REST_URL",
+    "WSS_URL",
+    "WS_INTERVALS",
+]

--- a/candles_feed/adapters/aevo/constants.py
+++ b/candles_feed/adapters/aevo/constants.py
@@ -1,0 +1,36 @@
+"""
+Common constants for the Aevo adapter.
+"""
+
+# API URLs and endpoints
+REST_URL = "https://api.aevo.xyz"
+CANDLES_ENDPOINT = "/mark-history"
+WSS_URL = "wss://ws.aevo.xyz"
+
+# API rate limits
+MAX_RESULTS_PER_CANDLESTICK_REST_REQUEST = 200
+
+# Intervals mapping: interval name -> seconds
+INTERVALS: dict[str, int] = {
+    "1m": 60,
+    "3m": 180,
+    "5m": 300,
+    "15m": 900,
+    "30m": 1800,
+    "1h": 3600,
+    "2h": 7200,
+    "4h": 14400,
+    "6h": 21600,
+    "8h": 28800,
+    "12h": 43200,
+    "1d": 86400,
+    "3d": 259200,
+    "1w": 604800,
+}
+
+# Aevo REST API expects resolution as number of seconds
+# Maps interval name to its resolution value in seconds (same as INTERVALS)
+INTERVAL_TO_EXCHANGE: dict[str, int] = dict(INTERVALS)
+
+# Websocket supported intervals
+WS_INTERVALS: list[str] = list(INTERVALS.keys())

--- a/candles_feed/adapters/aevo/perpetual_adapter.py
+++ b/candles_feed/adapters/aevo/perpetual_adapter.py
@@ -1,0 +1,261 @@
+"""
+Aevo perpetual exchange adapter for the Candle Feed framework.
+
+Aevo is a perpetuals-only exchange. The mark-history endpoint returns mark
+price data (not OHLCV), so open/high/low/close are all set to the mark price
+and volume is set to 0.0.
+"""
+
+from typing import Any
+
+from candles_feed.adapters.adapter_mixins import AsyncOnlyAdapter
+from candles_feed.adapters.base_adapter import BaseAdapter
+from candles_feed.core.candle_data import CandleData
+from candles_feed.core.exchange_registry import ExchangeRegistry
+from candles_feed.core.protocols import NetworkClientProtocol
+
+from .constants import (
+    CANDLES_ENDPOINT,
+    INTERVAL_TO_EXCHANGE,
+    INTERVALS,
+    MAX_RESULTS_PER_CANDLESTICK_REST_REQUEST,
+    REST_URL,
+    WS_INTERVALS,
+    WSS_URL,
+)
+
+# Nanoseconds divisor: Aevo timestamps are in nanoseconds
+_NS_TO_SECONDS: int = 1_000_000_000
+
+
+@ExchangeRegistry.register("aevo_perpetual")
+class AevoPerpetualAdapter(BaseAdapter, AsyncOnlyAdapter):
+    """Aevo perpetual exchange adapter.
+
+    Aevo only provides mark price history (not full OHLCV). All OHLC fields
+    are populated with the mark price, and volume is set to 0.0.
+
+    REST timestamp parameters are in nanoseconds; response timestamps are also
+    in nanoseconds and are converted to seconds for CandleData storage.
+
+    WebSocket uses a ticker channel at 500 ms granularity; the mark_price from
+    ticker messages is used to construct synthetic candles.
+    """
+
+    @staticmethod
+    def get_trading_pair_format(trading_pair: str) -> str:
+        """Convert standard trading pair format to Aevo instrument name.
+
+        :param trading_pair: Trading pair in standard format (e.g., "BTC-USDC")
+        :returns: Aevo instrument name (e.g., "BTC-PERP")
+        """
+        base, _ = trading_pair.split("-", 1)
+        return f"{base}-PERP"
+
+    def get_supported_intervals(self) -> dict[str, int]:
+        """Get supported intervals and their durations in seconds.
+
+        :returns: Dictionary mapping interval strings to their duration in seconds
+        """
+        return INTERVALS
+
+    def get_ws_url(self) -> str:
+        """Get WebSocket URL.
+
+        :returns: WebSocket URL
+        """
+        return self._get_ws_url()
+
+    def get_ws_supported_intervals(self) -> list[str]:
+        """Get intervals supported by WebSocket API.
+
+        :returns: List of interval strings supported by WebSocket API
+        """
+        return WS_INTERVALS
+
+    @staticmethod
+    def _get_rest_url() -> str:
+        """Get REST API URL for the mark-history endpoint.
+
+        :returns: Full REST API URL
+        """
+        return f"{REST_URL}{CANDLES_ENDPOINT}"
+
+    @staticmethod
+    def _get_ws_url() -> str:
+        """Get WebSocket URL.
+
+        :returns: WebSocket URL
+        """
+        return WSS_URL
+
+    def _get_rest_params(
+        self,
+        trading_pair: str,
+        interval: str,
+        start_time: int | None = None,
+        limit: int = MAX_RESULTS_PER_CANDLESTICK_REST_REQUEST,
+    ) -> dict[str, str | int]:
+        """Get parameters for the REST API request.
+
+        :param trading_pair: Trading pair in standard format (e.g., "BTC-USDC")
+        :param interval: Candle interval (e.g., "1m")
+        :param start_time: Start time in seconds (will be converted to nanoseconds)
+        :param limit: Maximum number of candles to return
+        :returns: Dictionary of parameters for the REST API request
+        """
+        instrument_name = AevoPerpetualAdapter.get_trading_pair_format(trading_pair)
+        resolution = INTERVAL_TO_EXCHANGE.get(interval, INTERVALS.get(interval, 60))
+
+        params: dict[str, str | int] = {
+            "instrument_name": instrument_name,
+            "resolution": resolution,
+            "limit": limit,
+        }
+
+        if start_time is not None:
+            params["start_timestamp"] = start_time * _NS_TO_SECONDS
+
+        return params
+
+    def _parse_rest_response(self, data: dict | list | None) -> list[CandleData]:
+        """Parse the REST API response into CandleData objects.
+
+        Aevo returns: {"history": [[timestamp_ns, price], ...]}
+
+        Since only mark price is provided, open/high/low/close are all set to
+        that price and volume is 0.0.
+
+        :param data: REST API response
+        :returns: List of CandleData objects
+        """
+        if data is None or not isinstance(data, dict):
+            return []
+
+        history = data.get("history")
+        if not history or not isinstance(history, list):
+            return []
+
+        candles: list[CandleData] = []
+        for entry in history:
+            if not isinstance(entry, list) or len(entry) < 2:
+                continue
+
+            timestamp_ns = int(entry[0])
+            timestamp_s = timestamp_ns // _NS_TO_SECONDS
+            price = float(entry[1])
+
+            candles.append(
+                CandleData(
+                    timestamp_raw=timestamp_s,
+                    open=price,
+                    high=price,
+                    low=price,
+                    close=price,
+                    volume=0.0,
+                    quote_asset_volume=0.0,
+                    n_trades=0,
+                    taker_buy_base_volume=0.0,
+                    taker_buy_quote_volume=0.0,
+                )
+            )
+
+        return candles
+
+    async def fetch_rest_candles(
+        self,
+        trading_pair: str,
+        interval: str,
+        start_time: int | None = None,
+        limit: int = MAX_RESULTS_PER_CANDLESTICK_REST_REQUEST,
+        network_client: NetworkClientProtocol | None = None,
+    ) -> list[CandleData]:
+        """Fetch candles from the REST API asynchronously.
+
+        :param trading_pair: Trading pair in standard format
+        :param interval: Candle interval
+        :param start_time: Start time in seconds
+        :param limit: Maximum number of candles to return
+        :param network_client: Network client to use for API requests
+        :returns: List of CandleData objects
+        """
+        return await AsyncOnlyAdapter._fetch_rest_candles(
+            adapter_implementation=self,
+            trading_pair=trading_pair,
+            interval=interval,
+            start_time=start_time,
+            limit=limit,
+            network_client=network_client,
+        )
+
+    def get_ws_subscription_payload(self, trading_pair: str, interval: str) -> dict:
+        """Get the WebSocket subscription payload.
+
+        Subscribes to the 500 ms ticker channel for the given instrument.
+        Aevo does not provide a candlestick WebSocket channel; the ticker
+        channel is used as a mark price feed.
+
+        :param trading_pair: Trading pair in standard format (e.g., "BTC-USDC")
+        :param interval: Candle interval (acknowledged but not sent to exchange)
+        :returns: WebSocket subscription payload
+        """
+        instrument_name = AevoPerpetualAdapter.get_trading_pair_format(trading_pair)
+        return {
+            "op": "subscribe",
+            "data": [f"ticker-500ms:{instrument_name}"],
+        }
+
+    def parse_ws_message(self, data: dict[str, Any] | None) -> list[CandleData] | None:
+        """Parse a WebSocket message into CandleData objects.
+
+        Expects Aevo ticker messages of the form:
+        {"type": "update", "channel": "ticker-500ms:BTC-PERP",
+         "data": {"mark_price": "50000.0", ...}}
+
+        Since Aevo tickers carry only mark price, all OHLC fields are set to
+        the mark_price and volume is 0.0. The timestamp is taken from wall
+        time via the message's ``timestamp`` field (nanoseconds) when present,
+        or the current exchange time.
+
+        :param data: WebSocket message dictionary
+        :returns: List with a single CandleData, or None if not a ticker update
+        """
+        if data is None:
+            return None
+
+        channel: str = data.get("channel", "")
+        if not channel.startswith("ticker-500ms:"):
+            return None
+
+        ticker_data = data.get("data")
+        if not isinstance(ticker_data, dict):
+            return None
+
+        mark_price_raw = ticker_data.get("mark_price")
+        if mark_price_raw is None:
+            return None
+
+        price = float(mark_price_raw)
+
+        # Prefer the message-level timestamp (nanoseconds); fall back to data-level
+        raw_ts = data.get("timestamp") or ticker_data.get("timestamp")
+        if raw_ts is not None:
+            timestamp_s = int(raw_ts) // _NS_TO_SECONDS
+        else:
+            # Use ensure_timestamp_in_seconds with None to get current time
+            timestamp_s = self.ensure_timestamp_in_seconds(None)
+
+        return [
+            CandleData(
+                timestamp_raw=timestamp_s,
+                open=price,
+                high=price,
+                low=price,
+                close=price,
+                volume=0.0,
+                quote_asset_volume=0.0,
+                n_trades=0,
+                taker_buy_base_volume=0.0,
+                taker_buy_quote_volume=0.0,
+            )
+        ]

--- a/candles_feed/adapters/ascend_ex/base_adapter.py
+++ b/candles_feed/adapters/ascend_ex/base_adapter.py
@@ -114,13 +114,17 @@ class AscendExBaseAdapter(BaseAdapter, AsyncOnlyAdapter):
         if data is None:
             return []
 
+        if not isinstance(data, dict):
+            return []
+
         candles: list[CandleData] = []
-        assert isinstance(data, dict), f"Unexpected data type: {type(data)}"
 
         for candle_item in data.get("data", []):
-            assert isinstance(candle_item, dict)
+            if not isinstance(candle_item, dict):
+                continue
             candle_payload = candle_item.get("data")
-            assert isinstance(candle_payload, dict)
+            if not isinstance(candle_payload, dict):
+                continue
 
             timestamp = self.ensure_timestamp_in_seconds(candle_payload["ts"])
             # timestamp = self.ensure_timestamp_in_seconds(candle["data"]["ts"]) # Erroneous duplicate line removed
@@ -207,7 +211,8 @@ class AscendExBaseAdapter(BaseAdapter, AsyncOnlyAdapter):
         # Check if this is a candle message
         if data.get("m") == "bar" and "data" in data:
             candle_payload = data["data"]
-            assert isinstance(candle_payload, dict)
+            if not isinstance(candle_payload, dict):
+                return None
             timestamp = self.ensure_timestamp_in_seconds(candle_payload["ts"])
             return [
                 CandleData(

--- a/candles_feed/adapters/binance/base_adapter.py
+++ b/candles_feed/adapters/binance/base_adapter.py
@@ -115,7 +115,8 @@ class BinanceBaseAdapter(BaseAdapter, AsyncOnlyAdapter):
             return []
 
         candles: list[CandleData] = []
-        assert isinstance(data, list), f"Unexpected data type: {type(data)}"
+        if not isinstance(data, list):
+            return []
         candles.extend(
             CandleData(
                 timestamp_raw=self.ensure_timestamp_in_seconds(row[0]),

--- a/candles_feed/adapters/bitget/__init__.py
+++ b/candles_feed/adapters/bitget/__init__.py
@@ -1,0 +1,35 @@
+"""
+Bitget exchange adapter package.
+"""
+
+from .constants import (
+    INTERVALS,
+    MAX_RESULTS_PER_CANDLESTICK_REST_REQUEST,
+    PERPETUAL_CANDLES_ENDPOINT,
+    PERPETUAL_INTERVAL_TO_EXCHANGE,
+    PERPETUAL_REST_URL,
+    SPOT_CANDLES_ENDPOINT,
+    SPOT_INTERVAL_TO_EXCHANGE,
+    SPOT_REST_URL,
+    WS_INTERVAL_TO_EXCHANGE,
+    WS_INTERVALS,
+    WSS_URL,
+)
+from .perpetual_adapter import BitgetPerpetualAdapter
+from .spot_adapter import BitgetSpotAdapter
+
+__all__ = [
+    "BitgetSpotAdapter",
+    "BitgetPerpetualAdapter",
+    "INTERVALS",
+    "MAX_RESULTS_PER_CANDLESTICK_REST_REQUEST",
+    "PERPETUAL_CANDLES_ENDPOINT",
+    "PERPETUAL_INTERVAL_TO_EXCHANGE",
+    "PERPETUAL_REST_URL",
+    "SPOT_CANDLES_ENDPOINT",
+    "SPOT_INTERVAL_TO_EXCHANGE",
+    "SPOT_REST_URL",
+    "WS_INTERVAL_TO_EXCHANGE",
+    "WS_INTERVALS",
+    "WSS_URL",
+]

--- a/candles_feed/adapters/bitget/constants.py
+++ b/candles_feed/adapters/bitget/constants.py
@@ -1,0 +1,85 @@
+"""
+Common constants for Bitget adapters.
+"""
+
+# Intervals mapping: interval name -> seconds
+INTERVALS: dict[str, int] = {
+    "1m": 60,
+    "3m": 180,
+    "5m": 300,
+    "15m": 900,
+    "30m": 1800,
+    "1h": 3600,
+    "4h": 14400,
+    "6h": 21600,
+    "12h": 43200,
+    "1d": 86400,
+    "3d": 259200,
+    "1w": 604800,
+}
+
+# Spot interval format - Bitget spot uses different naming
+SPOT_INTERVAL_TO_EXCHANGE: dict[str, str] = {
+    "1m": "1min",
+    "3m": "3min",
+    "5m": "5min",
+    "15m": "15min",
+    "30m": "30min",
+    "1h": "1h",
+    "4h": "4h",
+    "6h": "6h",
+    "12h": "12h",
+    "1d": "1day",
+    "3d": "3day",
+    "1w": "1week",
+}
+
+# Perpetual interval format - Bitget perpetual uses uppercase suffixes
+PERPETUAL_INTERVAL_TO_EXCHANGE: dict[str, str] = {
+    "1m": "1m",
+    "3m": "3m",
+    "5m": "5m",
+    "15m": "15m",
+    "30m": "30m",
+    "1h": "1H",
+    "4h": "4H",
+    "6h": "6H",
+    "12h": "12H",
+    "1d": "1D",
+    "3d": "3D",
+    "1w": "1W",
+}
+
+# WebSocket interval format - same as perpetual
+WS_INTERVAL_TO_EXCHANGE: dict[str, str] = {
+    "1m": "1m",
+    "3m": "3m",
+    "5m": "5m",
+    "15m": "15m",
+    "30m": "30m",
+    "1h": "1H",
+    "4h": "4H",
+    "6h": "6H",
+    "12h": "12H",
+    "1d": "1D",
+    "3d": "3D",
+    "1w": "1W",
+}
+
+# WebSocket supported intervals
+WS_INTERVALS: list[str] = list(WS_INTERVAL_TO_EXCHANGE.keys())
+
+# API rate limits
+MAX_RESULTS_PER_CANDLESTICK_REST_REQUEST = 1000
+
+# API URLs and endpoints
+# Spot
+SPOT_REST_URL = "https://api.bitget.com"
+SPOT_CANDLES_ENDPOINT = "/api/v2/spot/market/candles"
+
+# Perpetual
+PERPETUAL_REST_URL = "https://api.bitget.com"
+PERPETUAL_CANDLES_ENDPOINT = "/api/v2/mix/market/candles"
+
+# WebSocket
+WSS_URL = "wss://ws.bitget.com/v2/ws/public"

--- a/candles_feed/adapters/bitget/perpetual_adapter.py
+++ b/candles_feed/adapters/bitget/perpetual_adapter.py
@@ -1,0 +1,261 @@
+"""
+Bitget perpetual exchange adapter for the Candle Feed framework.
+"""
+
+from typing import Any
+
+from candles_feed.adapters.adapter_mixins import AsyncOnlyAdapter
+from candles_feed.adapters.base_adapter import BaseAdapter
+from candles_feed.core.candle_data import CandleData
+from candles_feed.core.exchange_registry import ExchangeRegistry
+from candles_feed.core.protocols import NetworkClientProtocol
+
+from .constants import (
+    INTERVALS,
+    MAX_RESULTS_PER_CANDLESTICK_REST_REQUEST,
+    PERPETUAL_CANDLES_ENDPOINT,
+    PERPETUAL_INTERVAL_TO_EXCHANGE,
+    PERPETUAL_REST_URL,
+    WS_INTERVAL_TO_EXCHANGE,
+    WS_INTERVALS,
+    WSS_URL,
+)
+
+# Mapping from quote asset to Bitget product type
+_QUOTE_TO_PRODUCT_TYPE: dict[str, str] = {
+    "USDT": "USDT-FUTURES",
+    "USDC": "USDC-FUTURES",
+    "USD": "COIN-FUTURES",
+}
+
+# Mapping from product type to WebSocket instType
+_PRODUCT_TYPE_TO_WS_INST_TYPE: dict[str, str] = {
+    "USDT-FUTURES": "USDT-FUTURES",
+    "USDC-FUTURES": "USDC-FUTURES",
+    "COIN-FUTURES": "COIN-FUTURES",
+}
+
+
+def _get_product_type(trading_pair: str) -> str:
+    """Determine Bitget product type from trading pair quote asset.
+
+    :param trading_pair: Trading pair in standard format (e.g., "BTC-USDT")
+    :returns: Bitget product type string
+    """
+    quote = trading_pair.split("-")[-1].upper() if "-" in trading_pair else ""
+    return _QUOTE_TO_PRODUCT_TYPE.get(quote, "USDT-FUTURES")
+
+
+@ExchangeRegistry.register("bitget_perpetual")
+class BitgetPerpetualAdapter(BaseAdapter, AsyncOnlyAdapter):
+    """Bitget perpetual exchange adapter."""
+
+    TIMESTAMP_UNIT: str = "milliseconds"
+
+    @staticmethod
+    def get_trading_pair_format(trading_pair: str) -> str:
+        """Convert standard trading pair format to exchange format.
+
+        :param trading_pair: Trading pair in standard format (e.g., "BTC-USDT")
+        :returns: Trading pair in Bitget perpetual format (e.g., "BTCUSDT")
+        """
+        return trading_pair.replace("-", "")
+
+    def get_supported_intervals(self) -> dict[str, int]:
+        """Get supported intervals and their durations in seconds.
+
+        :returns: Dictionary mapping interval strings to their duration in seconds
+        """
+        return INTERVALS
+
+    def get_ws_url(self) -> str:
+        """Get WebSocket URL.
+
+        :returns: WebSocket URL
+        """
+        return WSS_URL
+
+    def get_ws_supported_intervals(self) -> list[str]:
+        """Get intervals supported by WebSocket API.
+
+        :returns: List of interval strings supported by WebSocket API
+        """
+        return WS_INTERVALS
+
+    @staticmethod
+    def _get_rest_url() -> str:
+        """Get REST API URL for candles.
+
+        :returns: REST API URL
+        """
+        return f"{PERPETUAL_REST_URL}{PERPETUAL_CANDLES_ENDPOINT}"
+
+    def _get_rest_params(
+        self,
+        trading_pair: str,
+        interval: str,
+        start_time: int | None = None,
+        limit: int = MAX_RESULTS_PER_CANDLESTICK_REST_REQUEST,
+    ) -> dict[str, str | int]:
+        """Get parameters for REST API request.
+
+        :param trading_pair: Trading pair
+        :param interval: Candle interval
+        :param start_time: Start time in seconds
+        :param limit: Maximum number of candles to return
+        :returns: Dictionary of parameters for REST API request
+        """
+        product_type = _get_product_type(trading_pair)
+        params: dict[str, str | int] = {
+            "symbol": self.get_trading_pair_format(trading_pair),
+            "granularity": PERPETUAL_INTERVAL_TO_EXCHANGE.get(interval, interval),
+            "productType": product_type,
+            "limit": limit,
+        }
+
+        if start_time:
+            params["startTime"] = self.convert_timestamp_to_exchange(start_time)
+            params["endTime"] = self.convert_timestamp_to_exchange(
+                start_time + limit * INTERVALS.get(interval, 60)
+            )
+
+        return params
+
+    def _parse_rest_response(self, data: dict | list | None) -> list[CandleData]:
+        """Parse REST API response into CandleData objects.
+
+        Bitget perpetual candle format:
+        [
+          [
+            "1639984000000",  // timestamp (ms)
+            "47000.00",       // open
+            "47500.00",       // high
+            "46800.00",       // low
+            "47200.00",       // close
+            "123.456",        // volume (base asset)
+            "5823456.78"      // quote asset volume
+          ],
+          ...
+        ]
+
+        :param data: REST API response
+        :returns: List of CandleData objects
+        """
+        if data is None:
+            return []
+
+        # Bitget may wrap data in a "data" key or return direct array
+        if isinstance(data, dict):
+            candle_list = data.get("data")
+            if not isinstance(candle_list, list):
+                return []
+        elif isinstance(data, list):
+            candle_list = data
+        else:
+            return []
+
+        candles: list[CandleData] = []
+        for row in candle_list:
+            if not isinstance(row, list) or len(row) < 7:
+                continue
+            candles.append(
+                CandleData(
+                    timestamp_raw=self.ensure_timestamp_in_seconds(row[0]),
+                    open=float(row[1]),
+                    high=float(row[2]),
+                    low=float(row[3]),
+                    close=float(row[4]),
+                    volume=float(row[5]),
+                    quote_asset_volume=float(row[6]),
+                )
+            )
+        return candles
+
+    async def fetch_rest_candles(
+        self,
+        trading_pair: str,
+        interval: str,
+        start_time: int | None = None,
+        limit: int = MAX_RESULTS_PER_CANDLESTICK_REST_REQUEST,
+        network_client: NetworkClientProtocol | None = None,
+    ) -> list[CandleData]:
+        """Fetch candles from REST API asynchronously.
+
+        :param trading_pair: Trading pair
+        :param interval: Candle interval
+        :param start_time: Start time in seconds
+        :param limit: Maximum number of candles to return
+        :param network_client: Network client to use for API requests
+        :returns: List of CandleData objects
+        """
+        return await AsyncOnlyAdapter._fetch_rest_candles(
+            adapter_implementation=self,
+            trading_pair=trading_pair,
+            interval=interval,
+            start_time=start_time,
+            limit=limit,
+            network_client=network_client,
+        )
+
+    def get_ws_subscription_payload(self, trading_pair: str, interval: str) -> dict:
+        """Get WebSocket subscription payload.
+
+        :param trading_pair: Trading pair
+        :param interval: Candle interval
+        :returns: WebSocket subscription payload
+        """
+        exchange_interval = WS_INTERVAL_TO_EXCHANGE.get(interval, interval)
+        product_type = _get_product_type(trading_pair)
+        inst_type = _PRODUCT_TYPE_TO_WS_INST_TYPE.get(product_type, "USDT-FUTURES")
+        return {
+            "op": "subscribe",
+            "args": [
+                {
+                    "instType": inst_type,
+                    "channel": f"candle{exchange_interval}",
+                    "instId": self.get_trading_pair_format(trading_pair),
+                }
+            ],
+        }
+
+    def parse_ws_message(self, data: dict[str, Any] | None) -> list[CandleData] | None:
+        """Parse WebSocket message into CandleData objects.
+
+        Bitget WebSocket candle message format:
+        {
+          "action": "update",
+          "arg": {"instType": "USDT-FUTURES", "channel": "candle1m", "instId": "BTCUSDT"},
+          "data": [
+            ["1639984000000", "47000.00", "47500.00", "46800.00", "47200.00", "123.456", "5823456.78"]
+          ]
+        }
+
+        :param data: WebSocket message
+        :returns: List of CandleData objects or None if message is not a candle update
+        """
+        if data is None:
+            return None
+
+        # Only process "update" action messages
+        if data.get("action") != "update":
+            return None
+
+        raw_data = data.get("data")
+        if not isinstance(raw_data, list) or len(raw_data) == 0:
+            return None
+
+        row = raw_data[0]
+        if not isinstance(row, list) or len(row) < 7:
+            return None
+
+        return [
+            CandleData(
+                timestamp_raw=self.ensure_timestamp_in_seconds(row[0]),
+                open=float(row[1]),
+                high=float(row[2]),
+                low=float(row[3]),
+                close=float(row[4]),
+                volume=float(row[5]),
+                quote_asset_volume=float(row[6]),
+            )
+        ]

--- a/candles_feed/adapters/bitget/spot_adapter.py
+++ b/candles_feed/adapters/bitget/spot_adapter.py
@@ -1,0 +1,235 @@
+"""
+Bitget spot exchange adapter for the Candle Feed framework.
+"""
+
+from typing import Any
+
+from candles_feed.adapters.adapter_mixins import AsyncOnlyAdapter
+from candles_feed.adapters.base_adapter import BaseAdapter
+from candles_feed.core.candle_data import CandleData
+from candles_feed.core.exchange_registry import ExchangeRegistry
+from candles_feed.core.protocols import NetworkClientProtocol
+
+from .constants import (
+    INTERVALS,
+    MAX_RESULTS_PER_CANDLESTICK_REST_REQUEST,
+    SPOT_CANDLES_ENDPOINT,
+    SPOT_INTERVAL_TO_EXCHANGE,
+    SPOT_REST_URL,
+    WS_INTERVAL_TO_EXCHANGE,
+    WS_INTERVALS,
+    WSS_URL,
+)
+
+
+@ExchangeRegistry.register("bitget_spot")
+class BitgetSpotAdapter(BaseAdapter, AsyncOnlyAdapter):
+    """Bitget spot exchange adapter."""
+
+    TIMESTAMP_UNIT: str = "milliseconds"
+
+    @staticmethod
+    def get_trading_pair_format(trading_pair: str) -> str:
+        """Convert standard trading pair format to exchange format.
+
+        :param trading_pair: Trading pair in standard format (e.g., "BTC-USDT")
+        :returns: Trading pair in Bitget spot format (e.g., "BTCUSDT")
+        """
+        return trading_pair.replace("-", "")
+
+    def get_supported_intervals(self) -> dict[str, int]:
+        """Get supported intervals and their durations in seconds.
+
+        :returns: Dictionary mapping interval strings to their duration in seconds
+        """
+        return INTERVALS
+
+    def get_ws_url(self) -> str:
+        """Get WebSocket URL.
+
+        :returns: WebSocket URL
+        """
+        return WSS_URL
+
+    def get_ws_supported_intervals(self) -> list[str]:
+        """Get intervals supported by WebSocket API.
+
+        :returns: List of interval strings supported by WebSocket API
+        """
+        return WS_INTERVALS
+
+    @staticmethod
+    def _get_rest_url() -> str:
+        """Get REST API URL for candles.
+
+        :returns: REST API URL
+        """
+        return f"{SPOT_REST_URL}{SPOT_CANDLES_ENDPOINT}"
+
+    def _get_rest_params(
+        self,
+        trading_pair: str,
+        interval: str,
+        start_time: int | None = None,
+        limit: int = MAX_RESULTS_PER_CANDLESTICK_REST_REQUEST,
+    ) -> dict[str, str | int]:
+        """Get parameters for REST API request.
+
+        :param trading_pair: Trading pair
+        :param interval: Candle interval
+        :param start_time: Start time in seconds
+        :param limit: Maximum number of candles to return
+        :returns: Dictionary of parameters for REST API request
+        """
+        params: dict[str, str | int] = {
+            "symbol": self.get_trading_pair_format(trading_pair),
+            "granularity": SPOT_INTERVAL_TO_EXCHANGE.get(interval, interval),
+            "limit": limit,
+        }
+
+        if start_time:
+            params["startTime"] = self.convert_timestamp_to_exchange(start_time)
+            params["endTime"] = self.convert_timestamp_to_exchange(
+                start_time + limit * INTERVALS.get(interval, 60)
+            )
+
+        return params
+
+    def _parse_rest_response(self, data: dict | list | None) -> list[CandleData]:
+        """Parse REST API response into CandleData objects.
+
+        Bitget spot candle format:
+        [
+          [
+            "1639984000000",  // timestamp (ms)
+            "47000.00",       // open
+            "47500.00",       // high
+            "46800.00",       // low
+            "47200.00",       // close
+            "123.456",        // volume (base asset)
+            "5678.90",        // (unused field)
+            "5823456.78"      // quote asset volume
+          ],
+          ...
+        ]
+
+        :param data: REST API response
+        :returns: List of CandleData objects
+        """
+        if data is None:
+            return []
+
+        # Bitget may wrap data in a "data" key or return direct array
+        if isinstance(data, dict):
+            candle_list = data.get("data")
+            if not isinstance(candle_list, list):
+                return []
+        elif isinstance(data, list):
+            candle_list = data
+        else:
+            return []
+
+        candles: list[CandleData] = []
+        for row in candle_list:
+            if not isinstance(row, list) or len(row) < 8:
+                continue
+            candles.append(
+                CandleData(
+                    timestamp_raw=self.ensure_timestamp_in_seconds(row[0]),
+                    open=float(row[1]),
+                    high=float(row[2]),
+                    low=float(row[3]),
+                    close=float(row[4]),
+                    volume=float(row[5]),
+                    # row[6] is unused
+                    quote_asset_volume=float(row[7]),
+                )
+            )
+        return candles
+
+    async def fetch_rest_candles(
+        self,
+        trading_pair: str,
+        interval: str,
+        start_time: int | None = None,
+        limit: int = MAX_RESULTS_PER_CANDLESTICK_REST_REQUEST,
+        network_client: NetworkClientProtocol | None = None,
+    ) -> list[CandleData]:
+        """Fetch candles from REST API asynchronously.
+
+        :param trading_pair: Trading pair
+        :param interval: Candle interval
+        :param start_time: Start time in seconds
+        :param limit: Maximum number of candles to return
+        :param network_client: Network client to use for API requests
+        :returns: List of CandleData objects
+        """
+        return await AsyncOnlyAdapter._fetch_rest_candles(
+            adapter_implementation=self,
+            trading_pair=trading_pair,
+            interval=interval,
+            start_time=start_time,
+            limit=limit,
+            network_client=network_client,
+        )
+
+    def get_ws_subscription_payload(self, trading_pair: str, interval: str) -> dict:
+        """Get WebSocket subscription payload.
+
+        :param trading_pair: Trading pair
+        :param interval: Candle interval
+        :returns: WebSocket subscription payload
+        """
+        exchange_interval = WS_INTERVAL_TO_EXCHANGE.get(interval, interval)
+        return {
+            "op": "subscribe",
+            "args": [
+                {
+                    "instType": "SPOT",
+                    "channel": f"candle{exchange_interval}",
+                    "instId": self.get_trading_pair_format(trading_pair),
+                }
+            ],
+        }
+
+    def parse_ws_message(self, data: dict[str, Any] | None) -> list[CandleData] | None:
+        """Parse WebSocket message into CandleData objects.
+
+        Bitget WebSocket candle message format:
+        {
+          "action": "update",
+          "arg": {"instType": "SPOT", "channel": "candle1m", "instId": "BTCUSDT"},
+          "data": [
+            ["1639984000000", "47000.00", "47500.00", "46800.00", "47200.00", "123.456", "5823456.78"]
+          ]
+        }
+
+        :param data: WebSocket message
+        :returns: List of CandleData objects or None if message is not a candle update
+        """
+        if data is None:
+            return None
+
+        # Only process "update" action messages
+        if data.get("action") != "update":
+            return None
+
+        raw_data = data.get("data")
+        if not isinstance(raw_data, list) or len(raw_data) == 0:
+            return None
+
+        row = raw_data[0]
+        if not isinstance(row, list) or len(row) < 7:
+            return None
+
+        return [
+            CandleData(
+                timestamp_raw=self.ensure_timestamp_in_seconds(row[0]),
+                open=float(row[1]),
+                high=float(row[2]),
+                low=float(row[3]),
+                close=float(row[4]),
+                volume=float(row[5]),
+                quote_asset_volume=float(row[6]),
+            )
+        ]

--- a/candles_feed/adapters/bitmart/__init__.py
+++ b/candles_feed/adapters/bitmart/__init__.py
@@ -1,0 +1,29 @@
+"""
+Bitmart exchange adapter package.
+"""
+
+from .constants import (
+    CANDLES_ENDPOINT,
+    INTERVAL_TO_EXCHANGE_REST,
+    INTERVAL_TO_EXCHANGE_WS,
+    INTERVALS,
+    MAX_RESULTS_PER_CANDLESTICK_REST_REQUEST,
+    REST_URL,
+    WS_INTERVALS,
+    WSS_URL,
+)
+from .perpetual_adapter import BitmartPerpetualAdapter
+
+__all__ = [
+    # Adapters
+    "BitmartPerpetualAdapter",
+    # Constants
+    "CANDLES_ENDPOINT",
+    "INTERVAL_TO_EXCHANGE_REST",
+    "INTERVAL_TO_EXCHANGE_WS",
+    "INTERVALS",
+    "MAX_RESULTS_PER_CANDLESTICK_REST_REQUEST",
+    "REST_URL",
+    "WSS_URL",
+    "WS_INTERVALS",
+]

--- a/candles_feed/adapters/bitmart/constants.py
+++ b/candles_feed/adapters/bitmart/constants.py
@@ -1,0 +1,56 @@
+"""
+Common constants for Bitmart adapters.
+"""
+
+# API URLs and endpoints
+REST_URL = "https://api-cloud-v2.bitmart.com"
+CANDLES_ENDPOINT = "/contract/public/kline"
+WSS_URL = "wss://openapi-ws-v2.bitmart.com"
+
+# API rate limits
+MAX_RESULTS_PER_CANDLESTICK_REST_REQUEST = 1000
+
+# Intervals mapping: interval name -> seconds
+INTERVALS: dict[str, int] = {
+    "1m": 60,
+    "5m": 300,
+    "15m": 900,
+    "30m": 1800,
+    "1h": 3600,
+    "2h": 7200,
+    "4h": 14400,
+    "12h": 43200,
+    "1d": 86400,
+    "1w": 604800,
+}
+
+# Interval to exchange REST format: numeric minutes
+INTERVAL_TO_EXCHANGE_REST: dict[str, int] = {
+    "1m": 1,
+    "5m": 5,
+    "15m": 15,
+    "30m": 30,
+    "1h": 60,
+    "2h": 120,
+    "4h": 240,
+    "12h": 720,
+    "1d": 1440,
+    "1w": 10080,
+}
+
+# Interval to exchange WebSocket format
+INTERVAL_TO_EXCHANGE_WS: dict[str, str] = {
+    "1m": "1m",
+    "5m": "5m",
+    "15m": "15m",
+    "30m": "30m",
+    "1h": "1H",
+    "2h": "2H",
+    "4h": "4H",
+    "12h": "12H",
+    "1d": "1D",
+    "1w": "1W",
+}
+
+# Websocket supported intervals
+WS_INTERVALS: list[str] = list(INTERVAL_TO_EXCHANGE_WS.keys())

--- a/candles_feed/adapters/bitmart/perpetual_adapter.py
+++ b/candles_feed/adapters/bitmart/perpetual_adapter.py
@@ -127,9 +127,11 @@ class BitmartPerpetualAdapter(BaseAdapter, AsyncOnlyAdapter):
         if data is None:
             return []
 
-        assert isinstance(data, dict), f"Unexpected data type: {type(data)}"
+        if not isinstance(data, dict):
+            return []
         candle_list = data.get("data", [])
-        assert isinstance(candle_list, list), "data field is not a list"
+        if not isinstance(candle_list, list):
+            return []
 
         candles: list[CandleData] = []
         candles.extend(

--- a/candles_feed/adapters/bitmart/perpetual_adapter.py
+++ b/candles_feed/adapters/bitmart/perpetual_adapter.py
@@ -1,0 +1,242 @@
+"""
+Bitmart perpetual exchange adapter for the Candle Feed framework.
+"""
+
+import time
+from typing import Any
+
+from candles_feed.adapters.adapter_mixins import AsyncOnlyAdapter
+from candles_feed.adapters.base_adapter import BaseAdapter
+from candles_feed.core.candle_data import CandleData
+from candles_feed.core.exchange_registry import ExchangeRegistry
+from candles_feed.core.protocols import NetworkClientProtocol
+
+from .constants import (
+    CANDLES_ENDPOINT,
+    INTERVAL_TO_EXCHANGE_REST,
+    INTERVAL_TO_EXCHANGE_WS,
+    INTERVALS,
+    MAX_RESULTS_PER_CANDLESTICK_REST_REQUEST,
+    REST_URL,
+    WS_INTERVALS,
+    WSS_URL,
+)
+
+
+@ExchangeRegistry.register("bitmart_perpetual")
+class BitmartPerpetualAdapter(BaseAdapter, AsyncOnlyAdapter):
+    """Bitmart perpetual exchange adapter."""
+
+    TIMESTAMP_UNIT: str = "seconds"
+
+    @staticmethod
+    def get_trading_pair_format(trading_pair: str) -> str:
+        """Convert standard trading pair format to exchange format.
+
+        :param trading_pair: Trading pair in standard format (e.g., "BTC-USD")
+        :returns: Trading pair in Bitmart perpetual format (e.g., "BTCUSD")
+        """
+        return trading_pair.replace("-", "")
+
+    def get_supported_intervals(self) -> dict[str, int]:
+        """Get supported intervals and their durations in seconds.
+
+        :returns: Dictionary mapping interval strings to their duration in seconds
+        """
+        return INTERVALS
+
+    def get_ws_supported_intervals(self) -> list[str]:
+        """Get intervals supported by WebSocket API.
+
+        :returns: List of interval strings supported by WebSocket API
+        """
+        return WS_INTERVALS
+
+    def get_ws_url(self) -> str:
+        """Get WebSocket URL.
+
+        :returns: WebSocket URL
+        """
+        return WSS_URL
+
+    def _get_rest_url(self) -> str:
+        """Get REST API URL for candles.
+
+        :returns: REST API URL
+        """
+        return f"{REST_URL}{CANDLES_ENDPOINT}"
+
+    def _get_rest_params(
+        self,
+        trading_pair: str,
+        interval: str,
+        start_time: int | None = None,
+        limit: int = MAX_RESULTS_PER_CANDLESTICK_REST_REQUEST,
+    ) -> dict[str, str | int]:
+        """Get parameters for REST API request.
+
+        :param trading_pair: Trading pair
+        :param interval: Candle interval
+        :param start_time: Start time in seconds
+        :param limit: Maximum number of candles to return
+        :returns: Dictionary of parameters for REST API request
+
+        .. note::
+            Bitmart perpetual API requires both ``start_time`` and ``end_time``
+            to be provided together; omitting them results in a 400 Bad Request.
+            When ``start_time`` is not supplied, it is calculated as
+            ``now - limit * interval_seconds`` so the response covers the most
+            recent *limit* candles.
+        """
+        interval_seconds = INTERVALS[interval]
+        if start_time is None:
+            start_time = int(time.time()) - limit * interval_seconds
+
+        end_time = int(start_time) + limit * interval_seconds
+
+        return {
+            "symbol": self.get_trading_pair_format(trading_pair),
+            "step": INTERVAL_TO_EXCHANGE_REST[interval],
+            "start_time": int(start_time),
+            "end_time": end_time,
+        }
+
+    def _parse_rest_response(self, data: dict | list | None) -> list[CandleData]:
+        """Parse REST API response into CandleData objects.
+
+        :param data: REST API response
+        :returns: List of CandleData objects
+
+        Bitmart REST response format::
+
+            {
+                "code": 1000,
+                "data": [
+                    {
+                        "timestamp": 1631685600,
+                        "open_price": "46000.00",
+                        "high_price": "46500.00",
+                        "low_price": "45800.00",
+                        "close_price": "46200.00",
+                        "volume": "100"
+                    },
+                    ...
+                ]
+            }
+        """
+        if data is None:
+            return []
+
+        assert isinstance(data, dict), f"Unexpected data type: {type(data)}"
+        candle_list = data.get("data", [])
+        assert isinstance(candle_list, list), "data field is not a list"
+
+        candles: list[CandleData] = []
+        candles.extend(
+            CandleData(
+                timestamp_raw=self.ensure_timestamp_in_seconds(row["timestamp"]),
+                open=float(row["open_price"]),
+                high=float(row["high_price"]),
+                low=float(row["low_price"]),
+                close=float(row["close_price"]),
+                volume=float(row["volume"]),
+            )
+            for row in candle_list
+        )
+        return candles
+
+    async def fetch_rest_candles(
+        self,
+        trading_pair: str,
+        interval: str,
+        start_time: int | None = None,
+        limit: int = MAX_RESULTS_PER_CANDLESTICK_REST_REQUEST,
+        network_client: NetworkClientProtocol | None = None,
+    ) -> list[CandleData]:
+        """Fetch candles from REST API asynchronously.
+
+        :param trading_pair: Trading pair
+        :param interval: Candle interval
+        :param start_time: Start time in seconds
+        :param limit: Maximum number of candles to return
+        :param network_client: Network client to use for API requests
+        :returns: List of CandleData objects
+        """
+        return await AsyncOnlyAdapter._fetch_rest_candles(
+            adapter_implementation=self,
+            trading_pair=trading_pair,
+            interval=interval,
+            start_time=start_time,
+            limit=limit,
+            network_client=network_client,
+        )
+
+    def get_ws_subscription_payload(self, trading_pair: str, interval: str) -> dict:
+        """Get WebSocket subscription payload.
+
+        :param trading_pair: Trading pair
+        :param interval: Candle interval
+        :returns: WebSocket subscription payload
+
+        Bitmart WebSocket subscription format::
+
+            {
+                "action": "subscribe",
+                "args": ["futures/klineBin1m:BTCUSD"]
+            }
+        """
+        ws_interval = INTERVAL_TO_EXCHANGE_WS[interval]
+        symbol = self.get_trading_pair_format(trading_pair)
+        return {
+            "action": "subscribe",
+            "args": [f"futures/klineBin{ws_interval}:{symbol}"],
+        }
+
+    def parse_ws_message(self, data: dict[str, Any] | None) -> list[CandleData] | None:
+        """Parse WebSocket message into CandleData objects.
+
+        :param data: WebSocket message
+        :returns: List of CandleData objects or None if message is not a candle update
+
+        Bitmart WebSocket message format::
+
+            {
+                "data": {
+                    "items": [
+                        {
+                            "ts": 1631685600,
+                            "o": 46000.0,
+                            "h": 46500.0,
+                            "l": 45800.0,
+                            "c": 46200.0,
+                            "v": 100.0
+                        }
+                    ]
+                }
+            }
+        """
+        if data is None:
+            return None
+
+        inner = data.get("data")
+        if not isinstance(inner, dict):
+            return None
+
+        items = inner.get("items")
+        if not isinstance(items, list):
+            return None
+
+        candles: list[CandleData] = []
+        for item in items:
+            if isinstance(item, dict):
+                candles.append(
+                    CandleData(
+                        timestamp_raw=self.ensure_timestamp_in_seconds(item["ts"]),
+                        open=float(item["o"]),
+                        high=float(item["h"]),
+                        low=float(item["l"]),
+                        close=float(item["c"]),
+                        volume=float(item["v"]),
+                    )
+                )
+        return candles if candles else None

--- a/candles_feed/adapters/btc_markets/__init__.py
+++ b/candles_feed/adapters/btc_markets/__init__.py
@@ -1,0 +1,25 @@
+"""
+BTC Markets exchange adapter package.
+"""
+
+from .constants import (
+    CANDLES_ENDPOINT,
+    INTERVAL_TO_EXCHANGE_FORMAT,
+    INTERVALS,
+    MAX_RESULTS_PER_CANDLESTICK_REST_REQUEST,
+    REST_URL,
+    WS_INTERVALS,
+    WSS_URL,
+)
+from .spot_adapter import BTCMarketsSpotAdapter
+
+__all__ = [
+    "BTCMarketsSpotAdapter",
+    "CANDLES_ENDPOINT",
+    "INTERVAL_TO_EXCHANGE_FORMAT",
+    "INTERVALS",
+    "MAX_RESULTS_PER_CANDLESTICK_REST_REQUEST",
+    "REST_URL",
+    "WS_INTERVALS",
+    "WSS_URL",
+]

--- a/candles_feed/adapters/btc_markets/constants.py
+++ b/candles_feed/adapters/btc_markets/constants.py
@@ -1,0 +1,35 @@
+"""
+Common constants for BTC Markets adapters.
+"""
+
+# Intervals mapping: interval name -> seconds
+INTERVALS: dict[str, int] = {
+    "1m": 60,
+    "3m": 180,
+    "5m": 300,
+    "15m": 900,
+    "30m": 1800,
+    "1h": 3600,
+    "2h": 7200,
+    "3h": 10800,
+    "4h": 14400,
+    "6h": 21600,
+    "1d": 86400,
+    "1w": 604800,
+}
+
+# BTC Markets interval format matches our standard interval names
+INTERVAL_TO_EXCHANGE_FORMAT: dict[str, str] = {k: k for k in INTERVALS}
+
+# BTC Markets has no WebSocket support for candles
+WS_INTERVALS: list[str] = []
+
+# API rate limits
+MAX_RESULTS_PER_CANDLESTICK_REST_REQUEST = 1000
+
+# API URLs and endpoints
+REST_URL = "https://api.btcmarkets.net"
+CANDLES_ENDPOINT = "/v3/markets/{market_id}/candles"
+
+# BTC Markets has no WebSocket API for candles
+WSS_URL: str | None = None

--- a/candles_feed/adapters/btc_markets/spot_adapter.py
+++ b/candles_feed/adapters/btc_markets/spot_adapter.py
@@ -1,0 +1,194 @@
+"""
+BTC Markets spot exchange adapter for the Candle Feed framework.
+
+BTC Markets is an Australian cryptocurrency exchange. This adapter supports
+REST polling only - BTC Markets does not provide a WebSocket API for candles.
+"""
+
+from candles_feed.adapters.adapter_mixins import AsyncOnlyAdapter, NoWebSocketSupportMixin
+from candles_feed.adapters.base_adapter import BaseAdapter
+from candles_feed.core.candle_data import CandleData
+from candles_feed.core.exchange_registry import ExchangeRegistry
+from candles_feed.core.protocols import NetworkClientProtocol
+
+from .constants import (
+    CANDLES_ENDPOINT,
+    INTERVAL_TO_EXCHANGE_FORMAT,
+    INTERVALS,
+    MAX_RESULTS_PER_CANDLESTICK_REST_REQUEST,
+    REST_URL,
+    WS_INTERVALS,
+)
+
+
+@ExchangeRegistry.register("btc_markets_spot")
+class BTCMarketsSpotAdapter(NoWebSocketSupportMixin, BaseAdapter, AsyncOnlyAdapter):
+    """BTC Markets spot exchange adapter.
+
+    BTC Markets uses REST polling only for candle data. The candles endpoint
+    includes the market identifier in the URL path (e.g. ``/v3/markets/BTC-AUD/candles``).
+    Trading pairs are passed through unchanged (e.g. ``BTC-AUD``).
+
+    WebSocket candle streaming is not supported by BTC Markets.
+    """
+
+    TIMESTAMP_UNIT: str = "iso8601"
+
+    @staticmethod
+    def get_trading_pair_format(trading_pair: str) -> str:
+        """Convert standard trading pair format to BTC Markets exchange format.
+
+        BTC Markets uses the same hyphenated format as the candles-feed standard
+        (e.g. ``BTC-AUD``) so no conversion is required.
+
+        :param trading_pair: Trading pair in standard format (e.g., "BTC-AUD").
+        :returns: Trading pair in BTC Markets format (unchanged).
+        """
+        return trading_pair
+
+    def get_supported_intervals(self) -> dict[str, int]:
+        """Get supported intervals and their durations in seconds.
+
+        :returns: Dictionary mapping interval strings to their duration in seconds.
+        """
+        return INTERVALS
+
+    def get_ws_supported_intervals(self) -> list[str]:
+        """Get intervals supported by WebSocket API.
+
+        BTC Markets does not support WebSocket candle streaming, so this
+        always returns an empty list.
+
+        :returns: Empty list as WebSocket is not supported.
+        """
+        return WS_INTERVALS
+
+    def _get_rest_url(self) -> str:
+        """Get the REST API base URL for candles.
+
+        Returns the base URL without the endpoint path. The full candle URL
+        (including the market identifier in the path) is constructed in
+        ``fetch_rest_candles`` at request time.
+
+        :returns: REST API base URL.
+        """
+        return REST_URL
+
+    def _get_rest_url_for_pair(self, trading_pair: str) -> str:
+        """Build the full REST API URL for a specific trading pair.
+
+        BTC Markets embeds the market identifier in the URL path rather than
+        passing it as a query parameter.
+
+        :param trading_pair: Trading pair in standard format (e.g., "BTC-AUD").
+        :returns: Full REST API URL with market identifier substituted.
+        """
+        exchange_pair = self.get_trading_pair_format(trading_pair)
+        endpoint = CANDLES_ENDPOINT.format(market_id=exchange_pair)
+        return f"{REST_URL}{endpoint}"
+
+    def _get_rest_params(
+        self,
+        trading_pair: str,
+        interval: str,
+        start_time: int | None = None,
+        limit: int = MAX_RESULTS_PER_CANDLESTICK_REST_REQUEST,
+    ) -> dict[str, str | int]:
+        """Get query parameters for the REST API candles request.
+
+        BTC Markets uses ``timeWindow`` for the interval and ``from`` for the
+        optional start timestamp (in ISO 8601 format). The trading pair is
+        embedded in the URL path rather than passed as a parameter.
+
+        :param trading_pair: Trading pair (used for URL path, not query params).
+        :param interval: Candle interval (e.g., "1m", "1h").
+        :param start_time: Start time in seconds since epoch, or None for latest candles.
+        :param limit: Maximum number of candles to return.
+        :returns: Dictionary of query parameters for the REST API request.
+        """
+        params: dict[str, str | int] = {
+            "timeWindow": INTERVAL_TO_EXCHANGE_FORMAT.get(interval, interval),
+            "limit": limit,
+        }
+
+        if start_time is not None:
+            params["from"] = str(self.convert_timestamp_to_exchange(start_time))
+
+        return params
+
+    def _parse_rest_response(self, data: dict | list | None) -> list[CandleData]:
+        """Parse REST API response into CandleData objects.
+
+        BTC Markets candles endpoint returns an array of arrays in the form::
+
+            [
+                ["2024-01-01T00:00:00.000000Z", "open", "high", "low", "close", "volume"],
+                ...
+            ]
+
+        where index 0 is an ISO 8601 timestamp string and indices 1–5 are
+        numeric strings for open, high, low, close, and volume respectively.
+
+        :param data: REST API response (list of candle arrays).
+        :returns: List of CandleData objects parsed from the response.
+        """
+        if not isinstance(data, list):
+            return []
+
+        candles: list[CandleData] = []
+        for row in data:
+            if not isinstance(row, list) or len(row) < 6:
+                continue
+
+            candles.append(
+                CandleData(
+                    timestamp_raw=self.ensure_timestamp_in_seconds(row[0]),
+                    open=float(row[1]),
+                    high=float(row[2]),
+                    low=float(row[3]),
+                    close=float(row[4]),
+                    volume=float(row[5]),
+                )
+            )
+        return candles
+
+    async def fetch_rest_candles(
+        self,
+        trading_pair: str,
+        interval: str,
+        start_time: int | None = None,
+        limit: int = MAX_RESULTS_PER_CANDLESTICK_REST_REQUEST,
+        network_client: NetworkClientProtocol | None = None,
+    ) -> list[CandleData]:
+        """Fetch candles from the BTC Markets REST API.
+
+        Overrides the default implementation to build the URL with the trading
+        pair substituted into the path before making the request.
+
+        :param trading_pair: Trading pair (e.g., "BTC-AUD").
+        :param interval: Candle interval (e.g., "1m", "1h").
+        :param start_time: Start time in seconds since epoch, or None for latest candles.
+        :param limit: Maximum number of candles to return.
+        :param network_client: Network client to use for API requests.
+        :returns: List of CandleData objects.
+        :raises ValueError: If network_client is not provided.
+        """
+        if network_client is None:
+            raise ValueError("network_client is required for async operations")
+
+        url = self._get_rest_url_for_pair(trading_pair)
+        params = self._get_rest_params(
+            trading_pair=trading_pair,
+            interval=interval,
+            start_time=start_time,
+            limit=limit,
+        )
+
+        response = await network_client.get_rest_data(url=url, params=params)
+        return self._parse_rest_response(response)
+
+    # WebSocket methods (get_ws_url, get_ws_subscription_payload, parse_ws_message)
+    # are provided by NoWebSocketSupportMixin and all raise NotImplementedError.
+    #
+    # AsyncOnlyAdapter provides fetch_rest_candles_synchronous() which raises
+    # NotImplementedError, as this adapter is async-only.

--- a/candles_feed/adapters/bybit/base_adapter.py
+++ b/candles_feed/adapters/bybit/base_adapter.py
@@ -127,11 +127,14 @@ class BybitBaseAdapter(BaseAdapter, AsyncOnlyAdapter):
         if data is None:
             return []
 
-        assert isinstance(data, dict), f"Unexpected data type: {type(data)}"
+        if not isinstance(data, dict):
+            return []
         result_data = data.get("result", {})
-        assert isinstance(result_data, dict), "result field is not a dict"
+        if not isinstance(result_data, dict):
+            return []
         candle_list_data = result_data.get("list", [])
-        assert isinstance(candle_list_data, list), "list field is not a list"
+        if not isinstance(candle_list_data, list):
+            return []
 
         candles: list[CandleData] = []
         candles.extend(

--- a/candles_feed/adapters/dexalot/__init__.py
+++ b/candles_feed/adapters/dexalot/__init__.py
@@ -1,0 +1,25 @@
+"""
+Dexalot exchange adapter package.
+"""
+
+from .constants import (
+    CANDLES_ENDPOINT,
+    INTERVAL_TO_EXCHANGE_FORMAT,
+    INTERVALS,
+    MAX_RESULTS_PER_CANDLESTICK_REST_REQUEST,
+    REST_URL,
+    WS_INTERVALS,
+    WSS_URL,
+)
+from .spot_adapter import DexalotSpotAdapter
+
+__all__ = [
+    "DexalotSpotAdapter",
+    "CANDLES_ENDPOINT",
+    "INTERVAL_TO_EXCHANGE_FORMAT",
+    "INTERVALS",
+    "MAX_RESULTS_PER_CANDLESTICK_REST_REQUEST",
+    "REST_URL",
+    "WSS_URL",
+    "WS_INTERVALS",
+]

--- a/candles_feed/adapters/dexalot/constants.py
+++ b/candles_feed/adapters/dexalot/constants.py
@@ -1,0 +1,34 @@
+"""
+Common constants for Dexalot adapters.
+"""
+
+# API URLs and endpoints
+REST_URL = "https://api.dexalot.com/privapi"
+CANDLES_ENDPOINT = "/trading/candlechart"
+WSS_URL = "wss://api.dexalot.com/api/ws"
+
+# API rate limits
+MAX_RESULTS_PER_CANDLESTICK_REST_REQUEST = 1000
+
+# Intervals mapping: interval name -> seconds
+INTERVALS: dict[str, int] = {
+    "5m": 300,
+    "15m": 900,
+    "30m": 1800,
+    "1h": 3600,
+    "4h": 14400,
+    "1d": 86400,
+}
+
+# Dexalot interval formats - maps standard interval names to Dexalot exchange format
+INTERVAL_TO_EXCHANGE_FORMAT: dict[str, str] = {
+    "5m": "M5",
+    "15m": "M15",
+    "30m": "M30",
+    "1h": "H1",
+    "4h": "H4",
+    "1d": "D1",
+}
+
+# Websocket supported intervals
+WS_INTERVALS: list[str] = list(INTERVALS.keys())

--- a/candles_feed/adapters/dexalot/spot_adapter.py
+++ b/candles_feed/adapters/dexalot/spot_adapter.py
@@ -1,0 +1,274 @@
+"""
+Dexalot spot exchange adapter for the Candle Feed framework.
+"""
+
+from typing import Any
+
+from candles_feed.adapters.adapter_mixins import AsyncOnlyAdapter
+from candles_feed.adapters.base_adapter import BaseAdapter
+from candles_feed.core.candle_data import CandleData
+from candles_feed.core.exchange_registry import ExchangeRegistry
+from candles_feed.core.protocols import NetworkClientProtocol
+
+from .constants import (
+    CANDLES_ENDPOINT,
+    INTERVAL_TO_EXCHANGE_FORMAT,
+    INTERVALS,
+    MAX_RESULTS_PER_CANDLESTICK_REST_REQUEST,
+    REST_URL,
+    WS_INTERVALS,
+    WSS_URL,
+)
+
+
+@ExchangeRegistry.register("dexalot_spot")
+class DexalotSpotAdapter(BaseAdapter, AsyncOnlyAdapter):
+    """Dexalot spot exchange adapter.
+
+    Dexalot is a decentralized exchange. This adapter supports 6 intervals
+    and uses ISO 8601 timestamps for both REST and WebSocket APIs.
+    """
+
+    TIMESTAMP_UNIT: str = "iso8601"
+
+    @staticmethod
+    def get_trading_pair_format(trading_pair: str) -> str:
+        """Convert standard trading pair format to Dexalot exchange format.
+
+        :param trading_pair: Trading pair in standard format (e.g., "BTC-USD").
+        :returns: Trading pair in Dexalot format (e.g., "BTC/USD").
+        """
+        return trading_pair.replace("-", "/")
+
+    def get_supported_intervals(self) -> dict[str, int]:
+        """Get supported intervals and their durations in seconds.
+
+        :returns: Dictionary mapping interval strings to their duration in seconds.
+        """
+        return INTERVALS
+
+    def get_ws_url(self) -> str:
+        """Get WebSocket URL.
+
+        :returns: WebSocket URL.
+        """
+        return WSS_URL
+
+    def get_ws_supported_intervals(self) -> list[str]:
+        """Get intervals supported by WebSocket API.
+
+        :returns: List of interval strings supported by WebSocket API.
+        """
+        return WS_INTERVALS
+
+    @staticmethod
+    def _get_rest_url() -> str:
+        """Get REST API URL for candles.
+
+        :returns: REST API URL for candles endpoint.
+        """
+        return f"{REST_URL}{CANDLES_ENDPOINT}"
+
+    @staticmethod
+    def _interval_to_num_and_str(interval: str) -> tuple[str, str]:
+        """Convert standard interval string to Dexalot intervalnum and intervalstr.
+
+        The Dexalot API expects separate ``intervalnum`` and ``intervalstr`` params.
+        For example, ``"5m"`` → ``intervalnum="5"``, ``intervalstr="minute"``.
+
+        :param interval: Standard interval string (e.g., ``"5m"``, ``"1h"``, ``"1d"``).
+        :returns: Tuple of (intervalnum, intervalstr).
+        """
+        unit = interval[-1]
+        if unit == "m":
+            intervalstr = "minute"
+        elif unit == "h":
+            intervalstr = "hour"
+        elif unit == "d":
+            intervalstr = "day"
+        else:
+            intervalstr = ""
+        # Exchange format e.g. "M5" → numeric part is everything after the first char
+        exchange_fmt = INTERVAL_TO_EXCHANGE_FORMAT.get(interval, interval)
+        intervalnum = exchange_fmt[1:]
+        return intervalnum, intervalstr
+
+    def _get_rest_params(
+        self,
+        trading_pair: str,
+        interval: str,
+        start_time: int | None = None,
+        limit: int = MAX_RESULTS_PER_CANDLESTICK_REST_REQUEST,
+    ) -> dict[str, str | int]:
+        """Get parameters for REST API request.
+
+        The Dexalot API requires ``intervalnum`` (numeric part, e.g. ``"5"``) and
+        ``intervalstr`` (unit word, e.g. ``"minute"``) as separate parameters rather
+        than a combined ``interval`` field.
+
+        :param trading_pair: Trading pair.
+        :param interval: Candle interval.
+        :param start_time: Start time in seconds.
+        :param limit: Maximum number of candles to return (not used by Dexalot API).
+        :returns: Dictionary of parameters for REST API request.
+        """
+        intervalnum, intervalstr = self._interval_to_num_and_str(interval)
+        params: dict[str, str | int] = {
+            "pair": self.get_trading_pair_format(trading_pair),
+            "intervalnum": intervalnum,
+            "intervalstr": intervalstr,
+        }
+
+        if start_time is not None:
+            end_time = start_time + limit * INTERVALS[interval]
+            start_isotime = self.convert_timestamp_to_exchange(start_time)
+            end_isotime = self.convert_timestamp_to_exchange(end_time)
+            params["periodfrom"] = str(start_isotime)
+            params["periodto"] = str(end_isotime)
+
+        return params
+
+    def _parse_rest_response(self, data: dict | list | None) -> list[CandleData]:
+        """Parse REST API response into CandleData objects.
+
+        Dexalot REST API response format:
+        [
+            {
+                "date": "2024-01-01T00:00:00.000Z",
+                "open": 42000.0,
+                "high": 42500.0,
+                "low": 41800.0,
+                "close": 42200.0,
+                "volume": 1.5
+            },
+            ...
+        ]
+
+        :param data: REST API response.
+        :returns: List of CandleData objects.
+        """
+        if not isinstance(data, list):
+            return []
+
+        candles: list[CandleData] = []
+        for candle_item in data:
+            if not isinstance(candle_item, dict):
+                continue
+
+            raw_open = candle_item.get("open", 0)
+            raw_high = candle_item.get("high", 0)
+            raw_low = candle_item.get("low", 0)
+            raw_close = candle_item.get("close", 0)
+            raw_volume = candle_item.get("volume", 0)
+
+            candles.append(
+                CandleData(
+                    timestamp_raw=self.ensure_timestamp_in_seconds(
+                        candle_item.get("date", 0)
+                    ),
+                    open=float(raw_open) if raw_open != "None" and raw_open is not None else 0.0,
+                    high=float(raw_high) if raw_high != "None" and raw_high is not None else 0.0,
+                    low=float(raw_low) if raw_low != "None" and raw_low is not None else 0.0,
+                    close=float(raw_close) if raw_close != "None" and raw_close is not None else 0.0,
+                    volume=float(raw_volume) if raw_volume != "None" and raw_volume is not None else 0.0,
+                )
+            )
+        return candles
+
+    async def fetch_rest_candles(
+        self,
+        trading_pair: str,
+        interval: str,
+        start_time: int | None = None,
+        limit: int = MAX_RESULTS_PER_CANDLESTICK_REST_REQUEST,
+        network_client: NetworkClientProtocol | None = None,
+    ) -> list[CandleData]:
+        """Fetch candles from REST API asynchronously.
+
+        :param trading_pair: Trading pair.
+        :param interval: Candle interval.
+        :param start_time: Start time in seconds.
+        :param limit: Maximum number of candles to return.
+        :param network_client: Network client to use for API requests.
+        :returns: List of CandleData objects.
+        """
+        return await AsyncOnlyAdapter._fetch_rest_candles(
+            adapter_implementation=self,
+            trading_pair=trading_pair,
+            interval=interval,
+            start_time=start_time,
+            limit=limit,
+            network_client=network_client,
+        )
+
+    def get_ws_subscription_payload(self, trading_pair: str, interval: str) -> dict:
+        """Get WebSocket subscription payload.
+
+        :param trading_pair: Trading pair.
+        :param interval: Candle interval.
+        :returns: WebSocket subscription payload.
+        """
+        return {
+            "pair": self.get_trading_pair_format(trading_pair),
+            "chart": INTERVAL_TO_EXCHANGE_FORMAT.get(interval, interval),
+            "type": "chart-v2-subscribe",
+        }
+
+    def parse_ws_message(self, data: dict[str, Any] | None) -> list[CandleData] | None:
+        """Parse WebSocket message into CandleData objects.
+
+        Dexalot WebSocket message format:
+        {
+            "type": "liveCandle",
+            "data": [
+                {
+                    "date": "2024-01-01T00:05:00.000Z",
+                    "open": 42000.0,
+                    "high": 42500.0,
+                    "low": 41800.0,
+                    "close": 42200.0,
+                    "volume": 1.5
+                },
+                ...
+            ]
+        }
+        The last element of the data array (data[-1]) is the most current candle.
+
+        :param data: WebSocket message.
+        :returns: List of CandleData objects or None if message is not a candle update.
+        """
+        if data is None:
+            return None
+
+        if not isinstance(data, dict):
+            return None
+
+        if data.get("type") != "liveCandle":
+            return None
+
+        candle_array = data.get("data")
+        if not isinstance(candle_array, list) or len(candle_array) == 0:
+            return None
+
+        candle_item = candle_array[-1]
+        if not isinstance(candle_item, dict):
+            return None
+
+        raw_open = candle_item.get("open", 0)
+        raw_high = candle_item.get("high", 0)
+        raw_low = candle_item.get("low", 0)
+        raw_close = candle_item.get("close", 0)
+        raw_volume = candle_item.get("volume", 0)
+
+        return [
+            CandleData(
+                timestamp_raw=self.ensure_timestamp_in_seconds(
+                    candle_item.get("date", 0)
+                ),
+                open=float(raw_open) if raw_open != "None" and raw_open is not None else 0.0,
+                high=float(raw_high) if raw_high != "None" and raw_high is not None else 0.0,
+                low=float(raw_low) if raw_low != "None" and raw_low is not None else 0.0,
+                close=float(raw_close) if raw_close != "None" and raw_close is not None else 0.0,
+                volume=float(raw_volume) if raw_volume != "None" and raw_volume is not None else 0.0,
+            )
+        ]

--- a/candles_feed/adapters/pacifica/__init__.py
+++ b/candles_feed/adapters/pacifica/__init__.py
@@ -1,0 +1,25 @@
+"""
+Pacifica exchange adapter package.
+"""
+
+from .constants import (
+    CANDLES_ENDPOINT,
+    INTERVAL_TO_EXCHANGE_FORMAT,
+    INTERVALS,
+    MAX_RESULTS_PER_CANDLESTICK_REST_REQUEST,
+    REST_URL,
+    WS_INTERVALS,
+    WSS_URL,
+)
+from .perpetual_adapter import PacificaPerpetualAdapter
+
+__all__ = [
+    "PacificaPerpetualAdapter",
+    "CANDLES_ENDPOINT",
+    "INTERVAL_TO_EXCHANGE_FORMAT",
+    "INTERVALS",
+    "MAX_RESULTS_PER_CANDLESTICK_REST_REQUEST",
+    "REST_URL",
+    "WS_INTERVALS",
+    "WSS_URL",
+]

--- a/candles_feed/adapters/pacifica/constants.py
+++ b/candles_feed/adapters/pacifica/constants.py
@@ -1,0 +1,32 @@
+"""
+Common constants for Pacifica adapters.
+"""
+
+# Intervals mapping: interval name -> seconds
+INTERVALS: dict[str, int] = {
+    "1m": 60,
+    "3m": 180,
+    "5m": 300,
+    "15m": 900,
+    "30m": 1800,
+    "1h": 3600,
+    "2h": 7200,
+    "4h": 14400,
+    "8h": 28800,
+    "12h": 43200,
+    "1d": 86400,
+}
+
+# Pacifica uses the same interval format as our standard intervals
+INTERVAL_TO_EXCHANGE_FORMAT: dict[str, str] = {k: k for k in INTERVALS}
+
+# Websocket supported intervals
+WS_INTERVALS: list[str] = list(INTERVALS.keys())
+
+# API rate limits
+MAX_RESULTS_PER_CANDLESTICK_REST_REQUEST = 1000
+
+# API URLs and endpoints
+REST_URL = "https://api.pacifica.fi/api/v1"
+CANDLES_ENDPOINT = "/kline"
+WSS_URL = "wss://ws.pacifica.fi/ws"

--- a/candles_feed/adapters/pacifica/perpetual_adapter.py
+++ b/candles_feed/adapters/pacifica/perpetual_adapter.py
@@ -1,0 +1,268 @@
+"""
+Pacifica perpetual exchange adapter for the Candle Feed framework.
+"""
+
+import time
+from typing import Any
+
+from candles_feed.adapters.adapter_mixins import AsyncOnlyAdapter
+from candles_feed.adapters.base_adapter import BaseAdapter
+from candles_feed.core.candle_data import CandleData
+from candles_feed.core.exchange_registry import ExchangeRegistry
+from candles_feed.core.protocols import NetworkClientProtocol
+
+from .constants import (
+    CANDLES_ENDPOINT,
+    INTERVAL_TO_EXCHANGE_FORMAT,
+    INTERVALS,
+    MAX_RESULTS_PER_CANDLESTICK_REST_REQUEST,
+    REST_URL,
+    WS_INTERVALS,
+    WSS_URL,
+)
+
+
+@ExchangeRegistry.register("pacifica_perpetual")
+class PacificaPerpetualAdapter(BaseAdapter, AsyncOnlyAdapter):
+    """Pacifica perpetual exchange adapter.
+
+    Pacifica is a perpetual futures exchange. This adapter handles candle data
+    retrieval via REST and WebSocket using the Pacifica API.
+
+    Trading pair format: "BTC-USDC" -> "BTC" (base asset only, split on dash).
+    Timestamps: milliseconds.
+    """
+
+    TIMESTAMP_UNIT: str = "milliseconds"
+
+    @staticmethod
+    def get_trading_pair_format(trading_pair: str) -> str:
+        """Convert standard trading pair format to exchange format.
+
+        :param trading_pair: Trading pair in standard format (e.g., "BTC-USDC")
+        :returns: Trading pair in Pacifica format (e.g., "BTC")
+        """
+        base, _ = trading_pair.split("-", 1)
+        return base
+
+    def get_supported_intervals(self) -> dict[str, int]:
+        """Get supported intervals and their durations in seconds.
+
+        :returns: Dictionary mapping interval strings to their duration in seconds
+        """
+        return INTERVALS
+
+    def get_ws_url(self) -> str:
+        """Get WebSocket URL.
+
+        :returns: WebSocket URL
+        """
+        return self._get_ws_url()
+
+    def get_ws_supported_intervals(self) -> list[str]:
+        """Get intervals supported by WebSocket API.
+
+        :returns: List of interval strings supported by WebSocket API
+        """
+        return WS_INTERVALS
+
+    def _get_rest_url(self) -> str:
+        """Get REST API URL for candles.
+
+        :returns: REST API URL
+        """
+        return f"{REST_URL}{CANDLES_ENDPOINT}"
+
+    def _get_ws_url(self) -> str:
+        """Get WebSocket URL (internal implementation).
+
+        :returns: WebSocket URL
+        """
+        return WSS_URL
+
+    def _get_rest_params(
+        self,
+        trading_pair: str,
+        interval: str,
+        start_time: int | None = None,
+        limit: int = MAX_RESULTS_PER_CANDLESTICK_REST_REQUEST,
+    ) -> dict[str, str | int]:
+        """Get parameters for REST API request.
+
+        Pacifica requires both start_time and end_time in milliseconds.
+        If start_time is not provided, it is computed as now - (limit * interval_seconds).
+
+        :param trading_pair: Trading pair
+        :param interval: Candle interval
+        :param start_time: Start time in seconds (optional; defaults to now - limit*interval)
+        :param limit: Maximum number of candles to return
+        :returns: Dictionary of parameters for REST API request
+        """
+        symbol: str = self.get_trading_pair_format(trading_pair)
+        exchange_interval: str = INTERVAL_TO_EXCHANGE_FORMAT.get(interval, interval)
+        interval_seconds: int = INTERVALS.get(interval, 60)
+
+        now_ms: int = int(time.time() * 1000)
+
+        if start_time is not None:
+            start_ms: int = int(self.convert_timestamp_to_exchange(start_time))
+        else:
+            start_ms = now_ms - limit * interval_seconds * 1000
+
+        end_ms: int = start_ms + limit * interval_seconds * 1000
+
+        params: dict[str, str | int] = {
+            "symbol": symbol,
+            "interval": exchange_interval,
+            "start_time": start_ms,
+            "end_time": end_ms,
+            "limit": limit,
+        }
+
+        return params
+
+    def _parse_rest_response(self, data: dict | list | None) -> list[CandleData]:
+        """Parse REST API response into CandleData objects.
+
+        Pacifica REST response format:
+        {
+          "success": true,
+          "data": [
+            {
+              "t": <timestamp_ms>,
+              "o": <open>,
+              "h": <high>,
+              "l": <low>,
+              "c": <close>,
+              "v": <volume>,
+              "n": <n_trades>,
+              "T": <end_time_ms>,
+              "s": <symbol>,
+              "i": <interval>
+            },
+            ...
+          ]
+        }
+
+        :param data: REST API response
+        :returns: List of CandleData objects
+        """
+        if data is None:
+            return []
+
+        if isinstance(data, dict):
+            candle_list = data.get("data")
+        elif isinstance(data, list):
+            candle_list = data
+        else:
+            return []
+
+        if not candle_list or not isinstance(candle_list, list):
+            return []
+
+        candles: list[CandleData] = []
+        for row in candle_list:
+            if not isinstance(row, dict):
+                continue
+            candles.append(
+                CandleData(
+                    timestamp_raw=self.ensure_timestamp_in_seconds(row["t"]),
+                    open=float(row["o"]),
+                    high=float(row["h"]),
+                    low=float(row["l"]),
+                    close=float(row["c"]),
+                    volume=float(row["v"]),
+                    quote_asset_volume=0.0,
+                    n_trades=int(row.get("n", 0)),
+                    taker_buy_base_volume=0.0,
+                    taker_buy_quote_volume=0.0,
+                )
+            )
+        return candles
+
+    async def fetch_rest_candles(
+        self,
+        trading_pair: str,
+        interval: str,
+        start_time: int | None = None,
+        limit: int = MAX_RESULTS_PER_CANDLESTICK_REST_REQUEST,
+        network_client: NetworkClientProtocol | None = None,
+    ) -> list[CandleData]:
+        """Fetch candles from REST API asynchronously.
+
+        :param trading_pair: Trading pair
+        :param interval: Candle interval
+        :param start_time: Start time in seconds
+        :param limit: Maximum number of candles to return
+        :param network_client: Network client to use for API requests
+        :returns: List of CandleData objects
+        """
+        return await AsyncOnlyAdapter._fetch_rest_candles(
+            adapter_implementation=self,
+            trading_pair=trading_pair,
+            interval=interval,
+            start_time=start_time,
+            limit=limit,
+            network_client=network_client,
+        )
+
+    def get_ws_subscription_payload(self, trading_pair: str, interval: str) -> dict:
+        """Get WebSocket subscription payload.
+
+        :param trading_pair: Trading pair
+        :param interval: Candle interval
+        :returns: WebSocket subscription payload
+        """
+        pair: str = self.get_trading_pair_format(trading_pair)
+        exchange_interval: str = INTERVAL_TO_EXCHANGE_FORMAT.get(interval, interval)
+
+        return {
+            "method": "subscribe",
+            "params": {
+                "source": "candle",
+                "symbol": pair,
+                "interval": exchange_interval,
+            },
+        }
+
+    def parse_ws_message(self, data: dict[str, Any] | None) -> list[CandleData] | None:
+        """Parse WebSocket message into CandleData objects.
+
+        Pacifica WebSocket candle message format matches the REST data format:
+        {
+          "t": <timestamp_ms>,
+          "o": <open>,
+          "h": <high>,
+          "l": <low>,
+          "c": <close>,
+          "v": <volume>,
+          "n": <n_trades>,
+          "T": <end_time_ms>,
+          "s": <symbol>,
+          "i": <interval>
+        }
+
+        :param data: WebSocket message
+        :returns: List of CandleData objects or None if message is not a candle update
+        """
+        if data is None:
+            return None
+
+        # Candle messages carry the "t" (timestamp) field directly
+        if "t" not in data or "o" not in data:
+            return None
+
+        return [
+            CandleData(
+                timestamp_raw=self.ensure_timestamp_in_seconds(data["t"]),
+                open=float(data["o"]),
+                high=float(data["h"]),
+                low=float(data["l"]),
+                close=float(data["c"]),
+                volume=float(data["v"]),
+                quote_asset_volume=0.0,
+                n_trades=int(data.get("n", 0)),
+                taker_buy_base_volume=0.0,
+                taker_buy_quote_volume=0.0,
+            )
+        ]

--- a/candles_feed/hb_compat/adapter.py
+++ b/candles_feed/hb_compat/adapter.py
@@ -21,14 +21,14 @@ COLUMNS = [
 ]
 
 
-def _safe_float(value: object, default: float = 0.0) -> float:
+def _safe_float(value: float | int | str | None, default: float = 0.0) -> float:
     """Convert value to float, returning default for NaN/None."""
     if value is None or (isinstance(value, float) and pd.isna(value)):
         return default
     return float(value)
 
 
-def _safe_int(value: object, default: int = 0) -> int:
+def _safe_int(value: float | int | str | None, default: int = 0) -> int:
     """Convert value to int, returning default for NaN/None."""
     if value is None or (isinstance(value, float) and pd.isna(value)):
         return default

--- a/candles_feed/hb_compat/adapter.py
+++ b/candles_feed/hb_compat/adapter.py
@@ -21,6 +21,29 @@ COLUMNS = [
 ]
 
 
+def _safe_float(value: object, default: float = 0.0) -> float:
+    """Convert value to float, returning default for NaN/None."""
+    if value is None or (isinstance(value, float) and pd.isna(value)):
+        return default
+    return float(value)
+
+
+def _safe_int(value: object, default: int = 0) -> int:
+    """Convert value to int, returning default for NaN/None."""
+    if value is None or (isinstance(value, float) and pd.isna(value)):
+        return default
+    return int(value)
+
+
+# Attribute names on CandleData corresponding to COLUMNS order.
+_CANDLE_ATTRS = [
+    "timestamp", "open", "high", "low", "close", "volume",
+    "quote_asset_volume", "n_trades",
+    "taker_buy_base_volume", "taker_buy_quote_volume",
+]
+assert _CANDLE_ATTRS == COLUMNS, "COLUMNS and _CANDLE_ATTRS must match"
+
+
 class CandlesBaseAdapter:
     """Adapter implementing hummingbot's CandlesBase interface via CandlesFeed.
 
@@ -150,10 +173,10 @@ class CandlesBaseAdapter:
                 low=float(row["low"]),
                 close=float(row["close"]),
                 volume=float(row["volume"]),
-                quote_asset_volume=float(row.get("quote_asset_volume", 0.0)),
-                n_trades=int(row.get("n_trades", 0)),
-                taker_buy_base_volume=float(row.get("taker_buy_base_volume", 0.0)),
-                taker_buy_quote_volume=float(row.get("taker_buy_quote_volume", 0.0)),
+                quote_asset_volume=_safe_float(row.get("quote_asset_volume", 0.0)),
+                n_trades=_safe_int(row.get("n_trades", 0)),
+                taker_buy_base_volume=_safe_float(row.get("taker_buy_base_volume", 0.0)),
+                taker_buy_quote_volume=_safe_float(row.get("taker_buy_quote_volume", 0.0)),
             )
             self._feed.add_candle(candle)
 
@@ -167,15 +190,8 @@ class CandlesBaseAdapter:
         :return: ndarray of shape (N, 10), dtype float
         """
         if not candles:
-            return np.array([]).reshape(0, 10)
+            return np.array([]).reshape(0, len(COLUMNS))
         return np.array(
-            [
-                [
-                    c.timestamp, c.open, c.high, c.low, c.close, c.volume,
-                    c.quote_asset_volume, c.n_trades,
-                    c.taker_buy_base_volume, c.taker_buy_quote_volume,
-                ]
-                for c in candles
-            ],
+            [[getattr(c, attr) for attr in _CANDLE_ATTRS] for c in candles],
             dtype=float,
         )

--- a/candles_feed/hb_compat/factory.py
+++ b/candles_feed/hb_compat/factory.py
@@ -20,13 +20,30 @@ class CandlesFactory:
     # Hummingbot uses "binance" for spot; registry uses "binance_spot".
     # Perpetual names match directly (e.g., "binance_perpetual").
     _CONNECTOR_MAP: dict[str, str] = {
+        "aevo_perpetual": "aevo_perpetual",
+        "ascend_ex": "ascend_ex_spot",
         "binance": "binance_spot",
         "binance_perpetual": "binance_perpetual",
+        "bitget": "bitget_spot",
+        "bitget_perpetual": "bitget_perpetual",
+        "bitmart_perpetual": "bitmart_perpetual",
+        "btc_markets": "btc_markets_spot",
         "bybit": "bybit_spot",
+        "bybit_perpetual": "bybit_perpetual",
         "coinbase_advanced_trade": "coinbase_advanced_trade",
+        "dexalot": "dexalot_spot",
+        "gate_io": "gate_io_spot",
+        "gate_io_perpetual": "gate_io_perpetual",
+        "hyperliquid": "hyperliquid_spot",
+        "hyperliquid_perpetual": "hyperliquid_perpetual",
         "kraken": "kraken_spot",
         "kucoin": "kucoin_spot",
+        "kucoin_perpetual": "kucoin_perpetual",
+        "mexc": "mexc_spot",
+        "mexc_perpetual": "mexc_perpetual",
         "okx": "okx_spot",
+        "okx_perpetual": "okx_perpetual",
+        "pacifica_perpetual": "pacifica_perpetual",
     }
 
     @classmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -252,6 +252,7 @@ markers = [
     "e2e: marks tests as end-to-end tests",
     "asyncio: marks tests as asyncio tests",
     "benchmark: marks tests as performance benchmarks (deselect with '-m \"not benchmark\"')",
+    "live: marks tests that hit real exchange APIs (deselect with '-m \"not live\"')",
 ]
 log_cli = true
 log_cli_level = "DEBUG"
@@ -279,3 +280,43 @@ exclude = [
 [tool.bandit]
 exclude_dirs = ["tests"]
 skips = ["B101"]
+
+# Hummingbot sub-package supersession metadata.
+# Declares which hummingbot module this sub-package replaces, enabling automated
+# compatibility checking and test-skipping in hummingbot CI when this package is installed.
+[tool.hummingbot.supersedes]
+module = "hummingbot.data_feed.candles_feed"
+import_path = "candles_feed.hb_compat"
+factory_class = "CandlesFactory"
+config_class = "CandlesConfig"
+# Hummingbot test paths that this sub-package replaces.
+# When this package is importable, these tests are auto-skipped in CI.
+test_paths = ["test/hummingbot/data_feed/candles_feed"]
+# Only skip tests for exchanges/modules with adapters in this sub-package.
+# Tests for HB-only modules keep running unconditionally.
+connectors = [
+    "aevo_perpetual",
+    "ascend_ex",
+    "binance",
+    "binance_perpetual",
+    "bitget",
+    "bitget_perpetual",
+    "bitmart_perpetual",
+    "btc_markets",
+    "bybit",
+    "bybit_perpetual",
+    "coinbase_advanced_trade",
+    "dexalot",
+    "gate_io",
+    "gate_io_perpetual",
+    "hyperliquid",
+    "hyperliquid_perpetual",
+    "kraken",
+    "kucoin",
+    "kucoin_perpetual",
+    "mexc",
+    "mexc_perpetual",
+    "okx",
+    "okx_perpetual",
+    "pacifica_perpetual",
+]

--- a/tests/live/conftest.py
+++ b/tests/live/conftest.py
@@ -1,0 +1,19 @@
+"""Auto-skip live tests in CI environments."""
+
+import os
+
+import pytest
+
+# Detect CI environment (GitHub Actions, GitLab CI, etc.)
+IS_CI = os.environ.get("CI", "").lower() in ("true", "1")
+
+
+def pytest_collection_modifyitems(config, items):
+    """Skip all live-marked tests when running in CI."""
+    if not IS_CI:
+        return
+
+    skip_live = pytest.mark.skip(reason="Live tests disabled in CI (exchange APIs geo-blocked)")
+    for item in items:
+        if "live" in item.keywords:
+            item.add_marker(skip_live)

--- a/tests/live/test_rest_smoke.py
+++ b/tests/live/test_rest_smoke.py
@@ -1,0 +1,162 @@
+"""Live REST smoke tests for all exchange adapters.
+
+Fetches a small number of candles from each exchange's public API
+and validates basic data sanity. No authentication required.
+
+Run with: pixi run test-unit tests/live/ -v -m live
+Skip in CI: these tests hit real APIs and may be rate-limited.
+"""
+
+import time
+
+import pytest
+
+from candles_feed.core.candle_data import CandleData
+from candles_feed.core.exchange_registry import ExchangeRegistry
+from candles_feed.core.network_client import NetworkClient
+
+# Each entry: (registry_key, trading_pair, interval, expected_min_candles)
+# Trading pairs chosen for high liquidity on each exchange.
+CONNECTOR_TEST_CASES = [
+    # Spot adapters
+    ("ascend_ex_spot", "BTC-USDT", "1m", 3),
+    ("binance_spot", "BTC-USDT", "1m", 3),
+    ("bitget_spot", "BTC-USDT", "1m", 3),
+    ("btc_markets_spot", "BTC-AUD", "1m", 3),
+    ("bybit_spot", "BTC-USDT", "1m", 3),
+    ("coinbase_advanced_trade", "BTC-USD", "1m", 3),
+    ("dexalot_spot", "AVAX-USDC", "5m", 0),  # Dexalot DEX: low liquidity, may return 0
+    ("gate_io_spot", "BTC-USDT", "1m", 3),
+    ("hyperliquid_spot", "BTC-USDC", "1m", 3),
+    ("kraken_spot", "BTC-USD", "1m", 3),
+    ("kucoin_spot", "BTC-USDT", "1m", 3),
+    ("mexc_spot", "BTC-USDT", "1m", 3),
+    ("okx_spot", "BTC-USDT", "1m", 3),
+    # Perpetual adapters
+    ("aevo_perpetual", "BTC-USDC", "1m", 3),
+    ("binance_perpetual", "BTC-USDT", "1m", 3),
+    ("bitget_perpetual", "BTC-USDT", "1m", 3),
+    ("bitmart_perpetual", "BTC-USDT", "1m", 3),
+    ("bybit_perpetual", "BTC-USDT", "1m", 3),
+    ("gate_io_perpetual", "BTC-USDT", "1m", 3),
+    ("hyperliquid_perpetual", "BTC-USDC", "1m", 3),
+    ("kucoin_perpetual", "BTC-USDT", "1m", 3),
+    ("mexc_perpetual", "BTC-USDT", "1m", 3),
+    ("okx_perpetual", "BTC-USDT", "1m", 3),
+    ("pacifica_perpetual", "BTC-USDC", "1m", 3),
+]
+
+
+def _connector_id(val):
+    """Generate readable test IDs from parametrize tuples."""
+    if isinstance(val, tuple):
+        return val[0]
+    return str(val)
+
+
+@pytest.mark.live
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "registry_key,trading_pair,interval,min_candles",
+    CONNECTOR_TEST_CASES,
+    ids=[c[0] for c in CONNECTOR_TEST_CASES],
+)
+async def test_rest_fetch_candles(
+    registry_key: str,
+    trading_pair: str,
+    interval: str,
+    min_candles: int,
+):
+    """Smoke test: fetch candles from live exchange REST API.
+
+    Validates:
+    - Adapter can be instantiated from registry
+    - REST endpoint returns data
+    - Response parses into valid CandleData objects
+    - Timestamps are recent (within last 7 days)
+    - OHLCV values are positive
+    - High >= Low for each candle
+    """
+    adapter = ExchangeRegistry.get_adapter(registry_key)
+    assert adapter is not None, f"Adapter {registry_key} not found in registry"
+
+    async with NetworkClient() as client:
+        candles = await adapter.fetch_rest_candles(
+            trading_pair=trading_pair,
+            interval=interval,
+            limit=10,
+            network_client=client,
+        )
+
+    # Basic response validation
+    assert isinstance(candles, list), f"{registry_key}: expected list, got {type(candles)}"
+    assert len(candles) >= min_candles, (
+        f"{registry_key}: expected >= {min_candles} candles, got {len(candles)}"
+    )
+
+    now = time.time()
+    seven_days_ago = now - (7 * 24 * 3600)
+
+    for i, candle in enumerate(candles):
+        prefix = f"{registry_key}[{i}]"
+
+        # Type check
+        assert isinstance(candle, CandleData), f"{prefix}: not CandleData"
+
+        # Timestamp sanity: should be within last 7 days
+        assert candle.timestamp > seven_days_ago, (
+            f"{prefix}: timestamp {candle.timestamp} is older than 7 days"
+        )
+        assert candle.timestamp <= now + 120, (
+            f"{prefix}: timestamp {candle.timestamp} is in the future"
+        )
+
+        # Price sanity
+        assert candle.open > 0, f"{prefix}: open={candle.open} not positive"
+        assert candle.high > 0, f"{prefix}: high={candle.high} not positive"
+        assert candle.low > 0, f"{prefix}: low={candle.low} not positive"
+        assert candle.close > 0, f"{prefix}: close={candle.close} not positive"
+
+        # OHLC consistency
+        assert candle.high >= candle.low, (
+            f"{prefix}: high={candle.high} < low={candle.low}"
+        )
+        assert candle.high >= candle.open, (
+            f"{prefix}: high={candle.high} < open={candle.open}"
+        )
+        assert candle.high >= candle.close, (
+            f"{prefix}: high={candle.high} < close={candle.close}"
+        )
+        assert candle.low <= candle.open, (
+            f"{prefix}: low={candle.low} > open={candle.open}"
+        )
+        assert candle.low <= candle.close, (
+            f"{prefix}: low={candle.low} > close={candle.close}"
+        )
+
+        # Volume: non-negative (Aevo returns 0 for mark-price-only data)
+        assert candle.volume >= 0, f"{prefix}: volume={candle.volume} negative"
+
+
+@pytest.mark.live
+@pytest.mark.asyncio
+async def test_all_connectors_registered():
+    """Verify all expected connectors are in the ExchangeRegistry."""
+    registered = ExchangeRegistry.get_registered_exchanges()
+    expected = {c[0] for c in CONNECTOR_TEST_CASES}
+
+    missing = expected - set(registered)
+    assert not missing, f"Missing from registry: {missing}"
+
+
+@pytest.mark.live
+@pytest.mark.asyncio
+async def test_factory_roundtrip():
+    """Verify CandlesFactory can create adapters for all hummingbot connector names."""
+    from candles_feed.hb_compat.data_types import CandlesConfig
+    from candles_feed.hb_compat.factory import CandlesFactory
+
+    for connector_name in CandlesFactory.get_supported_connectors():
+        config = CandlesConfig(connector=connector_name, trading_pair="BTC-USDT")
+        adapter = CandlesFactory.get_candle(config)
+        assert adapter is not None, f"Factory returned None for {connector_name}"

--- a/tests/unit/hb_compat/test_adapter.py
+++ b/tests/unit/hb_compat/test_adapter.py
@@ -154,7 +154,18 @@ class TestCandlesBaseAdapterDataConversion:
             result = await adapter.fetch_candles(start_time=1000, end_time=1060)
             assert isinstance(result, np.ndarray)
             assert result.shape == (2, 10)
-            assert result[0, 0] == 1000
+            # Validate full column values for first row match _make_candle(1000, 100.0)
+            row = result[0]
+            assert row[0] == 1000        # timestamp
+            assert row[1] == 100.0       # open
+            assert row[2] == 101.0       # high
+            assert row[3] == 99.0        # low
+            assert row[4] == 100.5       # close
+            assert row[5] == 1000.0      # volume
+            assert row[6] == 100000.0    # quote_asset_volume
+            assert row[7] == 50          # n_trades
+            assert row[8] == 500.0       # taker_buy_base_volume
+            assert row[9] == 50000.0     # taker_buy_quote_volume
 
     @pytest.mark.asyncio
     async def test_fetch_candles_none_limit_defaults_to_500(self):
@@ -240,6 +251,47 @@ class TestCandlesBaseAdapterResetWithDataFrame:
         assert candles[1].open == 101.0
         assert candles[1].close == 101.5
         assert candles[1].volume == 1100.0
+
+    def test_reset_with_missing_optional_columns(self):
+        from candles_feed.hb_compat.adapter import CandlesBaseAdapter
+        adapter = CandlesBaseAdapter(
+            exchange="binance", trading_pair="BTC-USDT", max_records=10
+        )
+        df = pd.DataFrame([
+            [1000, 100.0, 101.0, 99.0, 100.5, 1000.0],
+        ], columns=["timestamp", "open", "high", "low", "close", "volume"])
+        adapter.reset_with_dataframe(df)
+
+        candles = adapter._feed.get_candles()
+        assert len(candles) == 1
+        assert candles[0].timestamp == 1000
+        assert candles[0].open == 100.0
+        assert candles[0].quote_asset_volume == 0.0
+        assert candles[0].n_trades == 0
+        assert candles[0].taker_buy_base_volume == 0.0
+        assert candles[0].taker_buy_quote_volume == 0.0
+
+    def test_reset_with_nan_optional_columns(self):
+        from candles_feed.hb_compat.adapter import CandlesBaseAdapter
+        adapter = CandlesBaseAdapter(
+            exchange="binance", trading_pair="BTC-USDT", max_records=10
+        )
+        df = pd.DataFrame([
+            [1000, 100.0, 101.0, 99.0, 100.5, 1000.0, float("nan"), float("nan"), float("nan"), float("nan")],
+        ], columns=[
+            "timestamp", "open", "high", "low", "close", "volume",
+            "quote_asset_volume", "n_trades",
+            "taker_buy_base_volume", "taker_buy_quote_volume",
+        ])
+        adapter.reset_with_dataframe(df)
+
+        candles = adapter._feed.get_candles()
+        assert len(candles) == 1
+        assert candles[0].open == 100.0
+        assert candles[0].quote_asset_volume == 0.0
+        assert candles[0].n_trades == 0
+        assert candles[0].taker_buy_base_volume == 0.0
+        assert candles[0].taker_buy_quote_volume == 0.0
 
     def test_reset_with_empty_dataframe(self):
         from candles_feed.hb_compat.adapter import CandlesBaseAdapter

--- a/tests/unit/hb_compat/test_factory.py
+++ b/tests/unit/hb_compat/test_factory.py
@@ -46,14 +46,31 @@ class TestCandlesFactory:
         from candles_feed.hb_compat.factory import CandlesFactory
 
         supported = CandlesFactory.get_supported_connectors()
+        assert "aevo_perpetual" in supported
+        assert "ascend_ex" in supported
         assert "binance" in supported
         assert "binance_perpetual" in supported
+        assert "bitget" in supported
+        assert "bitget_perpetual" in supported
+        assert "bitmart_perpetual" in supported
+        assert "btc_markets" in supported
         assert "bybit" in supported
+        assert "bybit_perpetual" in supported
         assert "coinbase_advanced_trade" in supported
+        assert "dexalot" in supported
+        assert "gate_io" in supported
+        assert "gate_io_perpetual" in supported
+        assert "hyperliquid" in supported
+        assert "hyperliquid_perpetual" in supported
         assert "kraken" in supported
         assert "kucoin" in supported
+        assert "kucoin_perpetual" in supported
+        assert "mexc" in supported
+        assert "mexc_perpetual" in supported
         assert "okx" in supported
-        assert len(supported) == 7
+        assert "okx_perpetual" in supported
+        assert "pacifica_perpetual" in supported
+        assert len(supported) == 24
 
     def test_get_supported_connectors_returns_copy(self):
         from candles_feed.hb_compat.factory import CandlesFactory


### PR DESCRIPTION
## Summary
- Fix `reset_with_dataframe` crash on NaN/None in optional columns (`int(NaN)` → `ValueError`)
- Wire `COLUMNS` constant into `_candle_data_list_to_ndarray` via `_CANDLE_ATTRS` with sync assertion
- Strengthen `test_fetch_candles_returns_ndarray` to validate all 10 column values
- Add tests for missing optional columns and NaN values in `reset_with_dataframe`

Addresses sourcery-ai review items 1, 3, 4 from PR #31. Item 2 (config field validation in `get_historical_candles`) intentionally not implemented — fields are ignored by design as documented in the docstring.

## Test plan
- [x] All 36 hb_compat unit tests pass
- [x] Lint clean
- [ ] CI validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add new exchange adapters and live REST smoke tests, expand connector mappings, and configure Hummingbot supersession metadata for the candles_feed package.

New Features:
- Introduce Aevo, Bitget (spot and perpetual), Bitmart perpetual, BTC Markets spot, Dexalot spot, and Pacifica perpetual exchange adapters with shared constant modules.
- Expose new adapters via the candles_feed.adapters package and register them in the exchange registry and Hummingbot compatibility factory.
- Add live REST smoke tests that validate basic candle data sanity across all supported adapters.

Enhancements:
- Expand CandlesFactory connector mapping and tests to cover newly supported exchanges and derivatives variants.
- Annotate tests with a new pytest 'live' marker and document how to run or skip live API tests in CI.

Build:
- Declare Hummingbot supersession metadata in pyproject.toml so this package can replace the core candles_feed module and associated tests in Hummingbot CI.