### PR TITLE
refactor: modernize test suite to pure pytest idioms

### DIFF
--- a/candles_feed/adapters/dexalot/spot_adapter.py
+++ b/candles_feed/adapters/dexalot/spot_adapter.py
@@ -163,14 +163,16 @@ class DexalotSpotAdapter(BaseAdapter, AsyncOnlyAdapter):
 
             candles.append(
                 CandleData(
-                    timestamp_raw=self.ensure_timestamp_in_seconds(
-                        candle_item.get("date", 0)
-                    ),
+                    timestamp_raw=self.ensure_timestamp_in_seconds(candle_item.get("date", 0)),
                     open=float(raw_open) if raw_open != "None" and raw_open is not None else 0.0,
                     high=float(raw_high) if raw_high != "None" and raw_high is not None else 0.0,
                     low=float(raw_low) if raw_low != "None" and raw_low is not None else 0.0,
-                    close=float(raw_close) if raw_close != "None" and raw_close is not None else 0.0,
-                    volume=float(raw_volume) if raw_volume != "None" and raw_volume is not None else 0.0,
+                    close=float(raw_close)
+                    if raw_close != "None" and raw_close is not None
+                    else 0.0,
+                    volume=float(raw_volume)
+                    if raw_volume != "None" and raw_volume is not None
+                    else 0.0,
                 )
             )
         return candles
@@ -262,13 +264,13 @@ class DexalotSpotAdapter(BaseAdapter, AsyncOnlyAdapter):
 
         return [
             CandleData(
-                timestamp_raw=self.ensure_timestamp_in_seconds(
-                    candle_item.get("date", 0)
-                ),
+                timestamp_raw=self.ensure_timestamp_in_seconds(candle_item.get("date", 0)),
                 open=float(raw_open) if raw_open != "None" and raw_open is not None else 0.0,
                 high=float(raw_high) if raw_high != "None" and raw_high is not None else 0.0,
                 low=float(raw_low) if raw_low != "None" and raw_low is not None else 0.0,
                 close=float(raw_close) if raw_close != "None" and raw_close is not None else 0.0,
-                volume=float(raw_volume) if raw_volume != "None" and raw_volume is not None else 0.0,
+                volume=float(raw_volume)
+                if raw_volume != "None" and raw_volume is not None
+                else 0.0,
             )
         ]

--- a/candles_feed/hb_compat/adapter.py
+++ b/candles_feed/hb_compat/adapter.py
@@ -15,9 +15,16 @@ from candles_feed.hb_compat.data_types import HistoricalCandlesConfig
 
 # Standard column order matching hummingbot's CandlesBase.columns
 COLUMNS = [
-    "timestamp", "open", "high", "low", "close", "volume",
-    "quote_asset_volume", "n_trades",
-    "taker_buy_base_volume", "taker_buy_quote_volume",
+    "timestamp",
+    "open",
+    "high",
+    "low",
+    "close",
+    "volume",
+    "quote_asset_volume",
+    "n_trades",
+    "taker_buy_base_volume",
+    "taker_buy_quote_volume",
 ]
 
 
@@ -37,9 +44,16 @@ def _safe_int(value: float | int | str | None, default: int = 0) -> int:
 
 # Attribute names on CandleData corresponding to COLUMNS order.
 _CANDLE_ATTRS = [
-    "timestamp", "open", "high", "low", "close", "volume",
-    "quote_asset_volume", "n_trades",
-    "taker_buy_base_volume", "taker_buy_quote_volume",
+    "timestamp",
+    "open",
+    "high",
+    "low",
+    "close",
+    "volume",
+    "quote_asset_volume",
+    "n_trades",
+    "taker_buy_base_volume",
+    "taker_buy_quote_volume",
 ]
 assert _CANDLE_ATTRS == COLUMNS, "COLUMNS and _CANDLE_ATTRS must match"
 
@@ -130,9 +144,7 @@ class CandlesBaseAdapter:
         )
         return self._candle_data_list_to_ndarray(candles)
 
-    async def get_historical_candles(
-        self, config: HistoricalCandlesConfig
-    ) -> pd.DataFrame:
+    async def get_historical_candles(self, config: HistoricalCandlesConfig) -> pd.DataFrame:
         """Get historical candles. Unpacks config, ignores redundant fields.
 
         :param config: Historical candles configuration

--- a/candles_feed/hb_compat/data_types.py
+++ b/candles_feed/hb_compat/data_types.py
@@ -31,6 +31,4 @@ class UnsupportedConnectorError(Exception):
 
     def __init__(self, connector: str):
         self.connector = connector
-        super().__init__(
-            f"Connector '{connector}' is not supported by hb-candles-feed."
-        )
+        super().__init__(f"Connector '{connector}' is not supported by hb-candles-feed.")

--- a/candles_feed/hb_compat/protocols.py
+++ b/candles_feed/hb_compat/protocols.py
@@ -65,9 +65,7 @@ class CandlesBaseProtocol(Protocol):
         """Fetch candles as numpy array."""
         ...
 
-    async def get_historical_candles(
-        self, config: HistoricalCandlesConfig
-    ) -> pd.DataFrame:
+    async def get_historical_candles(self, config: HistoricalCandlesConfig) -> pd.DataFrame:
         """Get historical candles using config object."""
         ...
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dev = [
     "pytest-cov>=4.1.0",
     "pytest-mock>=3.11.0",
     "pytest-timeout>=2.1.0",
+    "pytest-xdist>=3.0.0",
     "pyupgrade",
     "ruff>=0.1.6",
     "mypy>=1.5.1",
@@ -131,6 +132,7 @@ pytest-asyncio = ">=0.21.0"
 pytest-cov = ">=4.1.0"
 pytest-mock = ">=3.11.0"
 pytest-timeout = ">=2.1.0"
+pytest-xdist = ">=3.0.0"
 pytest-benchmark = ">=4.0.0"
 pyupgrade = "*"
 ruff = ">=0.1.6"

--- a/tests/e2e/test_candles_feed_with_mock_adapters.py
+++ b/tests/e2e/test_candles_feed_with_mock_adapters.py
@@ -17,7 +17,6 @@ from candles_feed.core.candles_feed import CandlesFeed
 from candles_feed.core.network_client import NetworkClient
 
 
-@pytest.mark.asyncio
 class TestCandlesFeedWithMockAdapters:
     """End-to-end tests for the Candles Feed with mock adapters."""
 
@@ -29,7 +28,6 @@ class TestCandlesFeedWithMockAdapters:
         # Make sure to close the client after the test
         await client.close()
 
-    @pytest.mark.asyncio
     async def test_candles_feed_with_sync_adapter(self, network_client):
         """Test CandlesFeed with SyncMockedAdapter."""
         # Setup - SyncMockedAdapter should already be registered with ExchangeRegistry
@@ -55,7 +53,6 @@ class TestCandlesFeedWithMockAdapters:
         # Stop the feed
         await feed.stop()
 
-    @pytest.mark.asyncio
     async def test_candles_feed_with_async_adapter(self, network_client):
         """Test CandlesFeed with AsyncMockedAdapter."""
         # Setup - AsyncMockedAdapter should already be registered with ExchangeRegistry
@@ -81,7 +78,6 @@ class TestCandlesFeedWithMockAdapters:
         # Stop the feed
         await feed.stop()
 
-    @pytest.mark.asyncio
     async def test_candles_feed_with_hybrid_adapter(self, network_client):
         """Test CandlesFeed with HybridMockedAdapter."""
         # Setup - HybridMockedAdapter should already be registered with ExchangeRegistry
@@ -115,7 +111,6 @@ class TestCandlesFeedWithMockAdapters:
         # Stop the feed
         await feed.stop()
 
-    @pytest.mark.asyncio
     async def test_multiple_candles_feeds_concurrently(self, network_client):
         """Test running multiple CandlesFeeds concurrently with different adapters."""
         # Setup - all adapters should already be registered with ExchangeRegistry

--- a/tests/e2e/test_end_to_end.py
+++ b/tests/e2e/test_end_to_end.py
@@ -147,7 +147,6 @@ class TestEndToEnd:
         # Teardown: stop the server
         await server.stop()
 
-    @pytest.mark.asyncio
     async def test_rest_candles_retrieval(self, aioresponses_mock_binance_server):
         """Test retrieving candles via REST API using aioresponses."""
         # Create a CandlesFeed instance
@@ -181,7 +180,6 @@ class TestEndToEnd:
             # Clean up resources
             await feed.stop()
 
-    @pytest.mark.asyncio
     async def test_multiple_trading_pairs(self, aioresponses_mock_binance_server):
         """Test working with multiple trading pairs simultaneously."""
         # Create feeds for different trading pairs

--- a/tests/integration/test_async_throttler_integration.py
+++ b/tests/integration/test_async_throttler_integration.py
@@ -43,7 +43,6 @@ class TestAsyncThrottlerIntegration:
         ]
         return MockAsyncThrottler(rate_limits)
 
-    @pytest.mark.asyncio
     async def test_throttler_adapter_basic_functionality(self, rate_limited_throttler):
         """Test basic functionality of HummingbotThrottlerAdapter."""
         adapter = HummingbotThrottlerAdapter(rate_limited_throttler)
@@ -61,7 +60,6 @@ class TestAsyncThrottlerIntegration:
         assert len(rate_limited_throttler.task_logs) == 1
         assert rate_limited_throttler.task_logs[0][0] == "api_calls"
 
-    @pytest.mark.asyncio
     async def test_throttler_adapter_rate_limiting(self, rate_limited_throttler):
         """Test rate limiting behavior of throttler adapter."""
         adapter = HummingbotThrottlerAdapter(rate_limited_throttler)
@@ -79,7 +77,6 @@ class TestAsyncThrottlerIntegration:
         assert len(rate_limited_throttler.task_logs) == 3
         assert all(log[0] == "api_calls" for log in rate_limited_throttler.task_logs)
 
-    @pytest.mark.asyncio
     async def test_throttler_different_limit_ids(self, rate_limited_throttler):
         """Test that different limit IDs work independently."""
         adapter = HummingbotThrottlerAdapter(rate_limited_throttler)
@@ -97,7 +94,6 @@ class TestAsyncThrottlerIntegration:
         task_ids = [log[0] for log in rate_limited_throttler.task_logs]
         assert task_ids == ["api_calls", "heavy_operations", "api_calls"]
 
-    @pytest.mark.asyncio
     async def test_throttler_error_handling(self):
         """Test error handling in throttler adapter."""
 
@@ -169,7 +165,6 @@ class TestWebAssistantsFactoryIntegration:
 
         return MockWebAssistantsFactory(rest_responses=rest_responses, ws_messages=ws_messages)
 
-    @pytest.mark.asyncio
     async def test_rest_assistant_creation(self, configured_factory):
         """Test REST assistant creation from factory."""
         rest_assistant = await configured_factory.get_rest_assistant()
@@ -177,7 +172,6 @@ class TestWebAssistantsFactoryIntegration:
         assert isinstance(rest_assistant, MockRESTAssistant)
         assert rest_assistant.connection is configured_factory.rest_connection
 
-    @pytest.mark.asyncio
     async def test_ws_assistant_creation(self, configured_factory):
         """Test WebSocket assistant creation from factory."""
         ws_assistant = await configured_factory.get_ws_assistant()
@@ -185,7 +179,6 @@ class TestWebAssistantsFactoryIntegration:
         assert isinstance(ws_assistant, MockWSAssistant)
         assert ws_assistant.connection is configured_factory.ws_connection
 
-    @pytest.mark.asyncio
     async def test_rest_assistant_api_calls(self, configured_factory):
         """Test REST API calls through assistant."""
         rest_assistant = await configured_factory.get_rest_assistant()
@@ -210,7 +203,6 @@ class TestWebAssistantsFactoryIntegration:
         assert requests[0]["method"] == "GET"
         assert requests[0]["params"]["symbol"] == "BTCUSDT"
 
-    @pytest.mark.asyncio
     async def test_ws_assistant_connection_and_messaging(self, configured_factory):
         """Test WebSocket connection and message handling."""
         ws_assistant = await configured_factory.get_ws_assistant()
@@ -240,7 +232,6 @@ class TestWebAssistantsFactoryIntegration:
         assert message_data["e"] == "kline"
         assert message_data["s"] == "BTCUSDT"
 
-    @pytest.mark.asyncio
     async def test_factory_async_context_manager(self, configured_factory):
         """Test factory as async context manager."""
         async with configured_factory as factory:
@@ -276,7 +267,6 @@ class TestHummingbotNetworkClientIntegration:
             rate_limits=[{"limit_id": "api_requests", "limit": 10, "time_interval": 1.0}],
         )
 
-    @pytest.mark.asyncio
     async def test_network_client_creation_with_components(self, integrated_components):
         """Test creating HummingbotNetworkClient with components."""
         with patch(
@@ -291,7 +281,6 @@ class TestHummingbotNetworkClientIntegration:
             assert client._web_assistants_factory is integrated_components["web_assistants_factory"]
             assert isinstance(client._throttler_adapter, HummingbotThrottlerAdapter)
 
-    @pytest.mark.asyncio
     async def test_network_client_rest_operations(self, integrated_components):
         """Test REST operations through network client."""
         with patch(
@@ -316,7 +305,6 @@ class TestHummingbotNetworkClientIntegration:
             throttler_logs = integrated_components["throttler"].task_logs
             assert len(throttler_logs) >= 1
 
-    @pytest.mark.asyncio
     async def test_network_client_websocket_operations(self, integrated_components):
         """Test WebSocket operations through network client."""
         with patch(
@@ -342,7 +330,6 @@ class TestHummingbotNetworkClientIntegration:
             assert len(sent_messages) == 1
             assert sent_messages[0]["method"] == "SUBSCRIBE"
 
-    @pytest.mark.asyncio
     async def test_network_client_context_manager(self, integrated_components):
         """Test network client as async context manager."""
         with patch(
@@ -359,7 +346,6 @@ class TestHummingbotNetworkClientIntegration:
                 response = await client.get_rest_data("https://api.test.com/ticker")
                 assert response["symbol"] == "BTCUSDT"
 
-    @pytest.mark.asyncio
     async def test_network_client_error_handling(self, integrated_components):
         """Test error handling in network client operations."""
         with patch(
@@ -381,7 +367,6 @@ class TestHummingbotNetworkClientIntegration:
 class TestNetworkClientFactory:
     """Test NetworkClientFactory component selection logic."""
 
-    @pytest.mark.asyncio
     async def test_factory_with_hummingbot_components(self):
         """Test factory creates HummingbotNetworkClient when components provided."""
         components = create_mock_hummingbot_components()
@@ -395,7 +380,6 @@ class TestNetworkClientFactory:
             assert client._throttler is components["throttler"]
             assert client._web_assistants_factory is components["web_assistants_factory"]
 
-    @pytest.mark.asyncio
     async def test_factory_fallback_to_standalone(self):
         """Test factory falls back to standalone client when components unavailable."""
         # Test with no components
@@ -409,7 +393,6 @@ class TestNetworkClientFactory:
 
             assert isinstance(client, NetworkClient)
 
-    @pytest.mark.asyncio
     async def test_factory_partial_components(self):
         """Test factory behavior with partial component set."""
         # Only provide throttler, no web_assistants_factory
@@ -449,7 +432,6 @@ class TestWSAssistantAdapter:
         ws_mock.iter_messages = mock_iter_messages
         return ws_mock
 
-    @pytest.mark.asyncio
     async def test_ws_adapter_basic_operations(self, mock_ws_assistant):
         """Test basic WebSocket adapter operations."""
         adapter = HummingbotWSAssistantAdapter(mock_ws_assistant)
@@ -464,7 +446,6 @@ class TestWSAssistantAdapter:
         await adapter.send("ping")
         mock_ws_assistant.send.assert_called_with("ping")
 
-    @pytest.mark.asyncio
     async def test_ws_adapter_message_iteration(self, mock_ws_assistant):
         """Test WebSocket message iteration and parsing."""
         adapter = HummingbotWSAssistantAdapter(mock_ws_assistant)
@@ -478,7 +459,6 @@ class TestWSAssistantAdapter:
         assert messages[0]["value"] == 123
         assert messages[1]["type"] == "ping"
 
-    @pytest.mark.asyncio
     async def test_ws_adapter_error_handling(self):
         """Test WebSocket adapter error handling."""
         # Create a mock that raises an exception
@@ -500,7 +480,6 @@ class TestWSAssistantAdapter:
             async for _ in adapter.iter_messages():
                 pass
 
-    @pytest.mark.asyncio
     async def test_ws_adapter_json_parse_error_handling(self, mock_ws_assistant):
         """Test handling of invalid JSON messages."""
 

--- a/tests/integration/test_candles_feed_integration.py
+++ b/tests/integration/test_candles_feed_integration.py
@@ -127,7 +127,6 @@ class TestCandlesFeedIntegration:
                 "bypass_network_selection", False
             )
 
-    @pytest.mark.asyncio
     async def test_rest_strategy_integration(self, standalone_mock_server):
         """Test CandlesFeed with REST polling strategy."""
         mock_server = standalone_mock_server
@@ -197,7 +196,6 @@ class TestCandlesFeedIntegration:
             # Stop the feed
             await feed.stop()
 
-    @pytest.mark.asyncio
     async def test_websocket_strategy_integration(self, standalone_mock_server):
         """Test CandlesFeed with WebSocket strategy."""
         mock_server = standalone_mock_server
@@ -367,7 +365,6 @@ class TestCandlesFeedIntegration:
             # Stop the feed
             await feed.stop()
 
-    @pytest.mark.asyncio
     async def test_multiple_feeds_integration(self, standalone_mock_server):
         """Test running multiple CandlesFeed instances simultaneously."""
         mock_server = standalone_mock_server
@@ -492,7 +489,6 @@ class TestCandlesFeedIntegration:
             # Stop all feeds
             await asyncio.gather(btc_feed.stop(), eth_feed.stop(), sol_feed.stop())
 
-    @pytest.mark.asyncio
     async def test_different_intervals_integration(self, standalone_mock_server):
         """Test CandlesFeed with different intervals."""
         mock_server = standalone_mock_server
@@ -567,7 +563,6 @@ class TestCandlesFeedIntegration:
             for _, feed in interval_feeds:
                 await feed.stop()
 
-    @pytest.mark.asyncio
     async def test_error_handling_integration(self, standalone_mock_server):
         """Test CandlesFeed error handling and recovery."""
         mock_server = standalone_mock_server
@@ -705,7 +700,6 @@ class TestCandlesFeedIntegration:
             # Stop the feed
             await feed.stop()
 
-    @pytest.mark.asyncio
     async def test_historical_data_fetch(self, standalone_mock_server):
         """Test fetching historical candle data with specific time ranges."""
         mock_server = standalone_mock_server

--- a/tests/integration/test_compatibility.py
+++ b/tests/integration/test_compatibility.py
@@ -133,7 +133,6 @@ class TestCompatibilityWithOriginal:
 
         return {"original": original_format, "new": new_format}
 
-    @pytest.mark.asyncio
     async def test_dataframe_format_compatibility(self, sample_candles_data):
         """Test that the DataFrame format is compatible with the original."""
         # Set up
@@ -200,7 +199,6 @@ class TestCompatibilityWithOriginal:
                         f"Value mismatch for {col} at index {i}"
                     )
 
-    @pytest.mark.asyncio
     async def test_historical_data_fetch_compatibility(self, sample_candles_data):
         """Test that historical data fetching is compatible with the original."""
         # Mock adapter
@@ -261,7 +259,6 @@ class TestCompatibilityWithOriginal:
             assert df.iloc[0]["timestamp"] == 1609459200, "First candle timestamp should match"
             assert df.iloc[1]["timestamp"] == 1609459260, "Second candle timestamp should match"
 
-    @pytest.mark.asyncio
     async def test_get_historical_candles_compatibility(self, sample_candles_data):
         """Test that get_historical_candles method is compatible with the original."""
         # Mock adapter
@@ -334,7 +331,6 @@ class TestCompatibilityWithOriginal:
                 "Second candle timestamp should match"
             )
 
-    @pytest.mark.asyncio
     async def test_timestamp_rounding_compatibility(self):
         """Test timestamp rounding compatibility."""
         # Mock adapter
@@ -401,7 +397,6 @@ class TestCompatibilityWithOriginal:
             rounded = feed_5m._round_timestamp_to_interval_multiple(timestamp)
             assert rounded == 1609459500, "5m rounding of boundary should not change"
 
-    @pytest.mark.asyncio
     async def test_ready_property_compatibility(self):
         """Test that the ready property is compatible with the original."""
         # Mock adapter
@@ -469,7 +464,6 @@ class TestCompatibilityWithOriginal:
             # Feed should be ready now (100% filled, which is > 90%)
             assert feed.ready, "Feed should be ready at 100% capacity"
 
-    @pytest.mark.asyncio
     async def test_check_candles_sorted_and_equidistant(self):
         """Test the check_candles_sorted_and_equidistant method for compatibility."""
         # Mock adapter
@@ -629,7 +623,6 @@ class TestCompatibilityWithOriginal:
                 "Should return False with non-equidistant candles"
             )
 
-    @pytest.mark.asyncio
     async def test_start_stop_compatibility(self):
         """Test that start/stop methods are compatible with the original."""
         # Mock adapter
@@ -716,7 +709,6 @@ class TestCompatibilityWithOriginal:
 class TestCandlesFeedWithHummingbotComponents:
     """Tests for compatibility with Hummingbot components."""
 
-    @pytest.mark.asyncio
     async def test_candles_feed_with_hummingbot_components(self):
         """Test candles feed with Hummingbot components."""
         # Initialize with a default value to satisfy static analysis

--- a/tests/integration/test_enhanced_dependency_management.py
+++ b/tests/integration/test_enhanced_dependency_management.py
@@ -160,7 +160,6 @@ class TestEnhancedDependencyManagement:
         except Exception as e:
             logger.warning(f"Error restoring URLs: {e}")
 
-    @pytest.mark.asyncio
     async def test_enhanced_network_condition_simulation(self, enhanced_mock_server):
         """Test enhanced network condition simulation for external dependencies."""
         logger.info("Testing enhanced network condition simulation")
@@ -247,7 +246,6 @@ class TestEnhancedDependencyManagement:
             if hasattr(feed, "_network_client") and feed._network_client:
                 await feed._network_client.close()
 
-    @pytest.mark.asyncio
     async def test_concurrent_external_dependency_access(self, enhanced_mock_server):
         """Test concurrent access to external dependencies with enhanced management."""
         logger.info("Testing concurrent external dependency access")
@@ -347,7 +345,6 @@ class TestEnhancedDependencyManagement:
                 if hasattr(feed_item, "_network_client") and feed_item._network_client:
                     await feed_item._network_client.close()
 
-    @pytest.mark.asyncio
     async def test_external_dependency_failure_recovery(self, enhanced_mock_server):
         """Test recovery from external dependency failures."""
         logger.info("Testing external dependency failure recovery")
@@ -449,7 +446,6 @@ class TestEnhancedDependencyManagement:
             )
             self.restore_feed_urls(feed, original_methods)
 
-    @pytest.mark.asyncio
     async def test_realistic_external_api_simulation(self, enhanced_mock_server):
         """Test realistic external API behavior simulation."""
         logger.info("Testing realistic external API behavior simulation")

--- a/tests/integration/test_key_exchange_adapters.py
+++ b/tests/integration/test_key_exchange_adapters.py
@@ -294,7 +294,6 @@ class TestBinanceSpotAdapter:
         )
         return feed
 
-    @pytest.mark.asyncio
     async def test_rest_candle_retrieval(self, binance_mock_server, binance_candles_feed):
         """Test REST API candle retrieval for Binance."""
         logger.info("Testing Binance REST candle retrieval")
@@ -328,7 +327,6 @@ class TestBinanceSpotAdapter:
 
         logger.info(f"  Binance REST: Fetched {len(candles)} candles successfully")
 
-    @pytest.mark.asyncio
     async def test_websocket_streaming(self, binance_mock_server, binance_candles_feed):
         """Test WebSocket streaming for Binance."""
         logger.info("Testing Binance WebSocket streaming")
@@ -366,7 +364,6 @@ class TestBinanceSpotAdapter:
 
         logger.info(f"  Binance WebSocket: Received {len(received_candles)} candles successfully")
 
-    @pytest.mark.asyncio
     async def test_multiple_intervals(self, binance_mock_server):
         """Test Binance adapter with multiple time intervals."""
         logger.info("Testing Binance multiple intervals")
@@ -396,7 +393,6 @@ class TestBinanceSpotAdapter:
 
             logger.info(f"  Binance {interval}: Fetched {len(candles)} candles")
 
-    @pytest.mark.asyncio
     async def test_error_handling(self, binance_mock_server, binance_candles_feed):
         """Test error handling and recovery for Binance."""
         logger.info("Testing Binance error handling")
@@ -422,7 +418,6 @@ class TestBinanceSpotAdapter:
 
         # The fixture's teardown will handle restarting/stopping the server cleanly for subsequent tests.
 
-    @pytest.mark.asyncio
     async def test_volume_and_trading_variations(self, binance_mock_server):
         """Test Binance adapter with different trading pairs and volumes."""
         logger.info("Testing Binance trading variations")
@@ -505,7 +500,6 @@ class TestCoinbaseAdvancedTradeAdapter:
         )
         return feed
 
-    @pytest.mark.asyncio
     async def test_rest_candle_retrieval(self, coinbase_mock_server, coinbase_candles_feed):
         """Test REST API candle retrieval for Coinbase."""
         logger.info("Testing Coinbase REST candle retrieval")
@@ -524,7 +518,6 @@ class TestCoinbaseAdvancedTradeAdapter:
 
         logger.info(f"  Coinbase REST: Fetched {len(candles)} candles successfully")
 
-    @pytest.mark.asyncio
     async def test_websocket_streaming(self, coinbase_mock_server, coinbase_candles_feed):
         """Test WebSocket streaming for Coinbase."""
         logger.info("Testing Coinbase WebSocket streaming")
@@ -547,7 +540,6 @@ class TestCoinbaseAdvancedTradeAdapter:
 
         logger.info(f"  Coinbase WebSocket: Received {len(received_candles)} candles")
 
-    @pytest.mark.asyncio
     async def test_usd_pairs_handling(self, coinbase_mock_server):
         """Test Coinbase's USD-based trading pairs."""
         logger.info("Testing Coinbase USD pairs")
@@ -572,7 +564,6 @@ class TestCoinbaseAdvancedTradeAdapter:
 
             logger.info(f"  Coinbase {pair}: {len(candles)} candles fetched")
 
-    @pytest.mark.asyncio
     async def test_coinbase_error_scenarios(self, coinbase_mock_server, coinbase_candles_feed):
         """Test Coinbase-specific error handling."""
         logger.info("Testing Coinbase error scenarios")
@@ -651,7 +642,6 @@ class TestBybitSpotAdapter:
         )
         return feed
 
-    @pytest.mark.asyncio
     async def test_rest_candle_retrieval(self, bybit_mock_server, bybit_candles_feed):
         """Test REST API candle retrieval for Bybit."""
         logger.info("Testing Bybit REST candle retrieval")
@@ -671,7 +661,6 @@ class TestBybitSpotAdapter:
 
         logger.info(f"  Bybit REST: Fetched {len(candles)} candles successfully")
 
-    @pytest.mark.asyncio
     async def test_websocket_streaming(self, bybit_mock_server, bybit_candles_feed):
         """Test WebSocket streaming for Bybit."""
         logger.info("Testing Bybit WebSocket streaming")
@@ -702,7 +691,6 @@ class TestBybitSpotAdapter:
         # The test passes if the WebSocket strategy can be started and stopped without crashing
         logger.info("Bybit WebSocket streaming test completed successfully")
 
-    @pytest.mark.asyncio
     async def test_bybit_specific_features(self, bybit_mock_server):
         """Test Bybit-specific features and data handling."""
         logger.info("Testing Bybit specific features")
@@ -738,7 +726,6 @@ class TestBybitSpotAdapter:
 class TestCrossAdapterCompatibility:
     """Test compatibility and consistency across different exchange adapters."""
 
-    @pytest.mark.asyncio
     async def test_data_format_consistency(self, unused_tcp_port):
         """Test that all adapters return data in consistent format."""
         logger.info("Testing cross-adapter data format consistency")
@@ -828,7 +815,6 @@ class TestCrossAdapterCompatibility:
 
                 logger.info(f"  {adapter_name} format matches {reference_adapter}")
 
-    @pytest.mark.asyncio
     async def test_performance_comparison(self, unused_tcp_port):
         """Test performance characteristics across adapters using mock servers."""
         logger.info("Testing adapter performance comparison")
@@ -908,7 +894,6 @@ class TestCrossAdapterCompatibility:
             assert metrics["duration"] < 5.0, f"{exchange} should fetch data in reasonable time"
             assert metrics["candles_count"] > 0, f"{exchange} should return candles"
 
-    @pytest.mark.asyncio
     async def test_error_handling_consistency(self, unused_tcp_port):
         """Test that all adapters handle errors consistently using mock servers."""
         logger.info("Testing consistent error handling across adapters")
@@ -987,7 +972,6 @@ class TestCrossAdapterCompatibility:
 class TestIntegrationSummary:
     """Summary and validation of all integration tests."""
 
-    @pytest.mark.asyncio
     async def test_integration_coverage_summary(self):
         """Validate that integration tests cover all required scenarios."""
         logger.info("=== Integration Test Coverage Summary ===")

--- a/tests/integration/test_mock_adapters.py
+++ b/tests/integration/test_mock_adapters.py
@@ -27,7 +27,6 @@ from candles_feed.mocking_resources.adapter import (
 )
 
 
-@pytest.mark.asyncio
 @pytest.mark.integration
 class TestMockAdaptersWithStrategies:
     """Test how mock adapters interact with collection strategies."""
@@ -50,7 +49,6 @@ class TestMockAdaptersWithStrategies:
         # Make sure to close the client after the test
         await client.close()
 
-    @pytest.mark.asyncio
     async def test_sync_adapter_with_rest_strategy(
         self, data_processor, candles_store, network_client
     ):
@@ -79,7 +77,6 @@ class TestMockAdaptersWithStrategies:
         timestamps = [c.timestamp for c in candles]
         assert timestamps == sorted(timestamps)
 
-    @pytest.mark.asyncio
     async def test_async_adapter_with_rest_strategy(
         self, data_processor, candles_store, network_client
     ):
@@ -104,7 +101,6 @@ class TestMockAdaptersWithStrategies:
         assert candles[1].open == 101.0
         assert candles[-1].open == 109.0
 
-    @pytest.mark.asyncio
     async def test_hybrid_adapter_with_rest_strategy(
         self, data_processor, candles_store, network_client
     ):
@@ -130,7 +126,6 @@ class TestMockAdaptersWithStrategies:
         assert candles[1].open == 202.0
         assert candles[-1].open == 218.0
 
-    @pytest.mark.asyncio
     async def test_factory_selects_websocket_strategy(
         self, data_processor, candles_store, network_client
     ):
@@ -156,7 +151,6 @@ class TestMockAdaptersWithStrategies:
         # Verify it's a WebSocketStrategy
         assert isinstance(strategy, WebSocketStrategy)
 
-    @pytest.mark.asyncio
     async def test_factory_gracefully_handles_websocket_not_supported(
         self, data_processor, candles_store, network_client
     ):
@@ -180,7 +174,6 @@ class TestMockAdaptersWithStrategies:
         # Verify it's a RESTPollingStrategy
         assert isinstance(strategy, RESTPollingStrategy)
 
-    @pytest.mark.asyncio
     async def test_adapter_with_collection_strategy_lifecycle(
         self, data_processor, candles_store, network_client
     ):

--- a/tests/integration/test_mock_server.py
+++ b/tests/integration/test_mock_server.py
@@ -60,7 +60,6 @@ class TestMockServer:
         # Clean up
         await server.stop()
 
-    @pytest.mark.asyncio
     async def test_server_rest_endpoints(self, standalone_mock_server):
         """Test the REST endpoints of the mock server."""
         mock_server_url = standalone_mock_server.url
@@ -100,7 +99,6 @@ class TestMockServer:
                 assert isinstance(first_candle[4], str), "Close price should be a string"
                 assert isinstance(first_candle[5], str), "Volume should be a string"
 
-    @pytest.mark.asyncio
     async def test_server_websocket_connection_simple(self, standalone_mock_server):
         """Test basic WebSocket connection to the mock server."""
         server_host = standalone_mock_server.host
@@ -141,7 +139,6 @@ class TestMockServer:
             # This test is simplified to just verify we can establish a connection
             # and receive a subscription response
 
-    @pytest.mark.asyncio
     async def test_server_multiple_trading_pairs(self):
         """Test the mock server with multiple trading pairs."""
         # Create a new server instance for this test
@@ -214,7 +211,6 @@ class TestMockServer:
             # Stop the server
             await server.stop()
 
-    @pytest.mark.asyncio
     async def test_server_network_simulation(self, standalone_mock_server):
         """Test the network simulation features of the mock server."""
         mock_server_url = standalone_mock_server.url
@@ -282,7 +278,6 @@ class TestMockServer:
             data = await response.json()
             assert len(data) > 0
 
-    @pytest.mark.asyncio
     async def test_mock_candle_data_methods(self):
         """Test that the CandleData class can create realistic candle sequences."""
         # Start with a base timestamp and price
@@ -340,7 +335,6 @@ class TestMockServer:
         assert min_price >= base_price * 0.9, f"Min price {min_price} too low"
         assert max_price <= base_price * 1.1, f"Max price {max_price} too high"
 
-    @pytest.mark.asyncio
     async def test_mock_candle_data_creation(self):
         """Test creating and manipulating CandleData objects."""
         # Test creating a basic candle

--- a/tests/integration/test_mock_server_with_aiohttp.py
+++ b/tests/integration/test_mock_server_with_aiohttp.py
@@ -151,7 +151,6 @@ async def spot_adapter(client):
 
 
 # Test cases
-@pytest.mark.asyncio
 async def test_ping_endpoint(client):
     """Test the ping endpoint."""
     # Send a request to the ping endpoint
@@ -163,7 +162,6 @@ async def test_ping_endpoint(client):
     assert data == {}
 
 
-@pytest.mark.asyncio
 async def test_time_endpoint(client):
     """Test the time endpoint."""
     # Send a request to the time endpoint
@@ -176,7 +174,6 @@ async def test_time_endpoint(client):
     assert isinstance(data["serverTime"], int)
 
 
-@pytest.mark.asyncio
 async def test_klines_endpoint(client):
     """Test the klines endpoint."""
     # Send a request to the klines endpoint
@@ -203,7 +200,6 @@ async def test_klines_endpoint(client):
         assert isinstance(candle[5], str)  # Volume
 
 
-@pytest.mark.asyncio
 async def test_error_handling(client):
     """Test error handling for invalid parameters."""
     # Send a request with an invalid symbol

--- a/tests/integration/test_service_container_integration.py
+++ b/tests/integration/test_service_container_integration.py
@@ -168,7 +168,6 @@ class TestServiceContainerIntegration:
         """Check if WebSocket echo server is available."""
         return os.getenv("TEST_WITH_SERVICES", "false").lower() == "true"
 
-    @pytest.mark.asyncio
     async def test_redis_caching_integration(self, redis_client, mock_server_with_caching):
         """Test integration with Redis for caching candle data."""
         if not HAS_REDIS:
@@ -229,7 +228,6 @@ class TestServiceContainerIntegration:
         # Clean up
         await redis_client.delete(cache_key)
 
-    @pytest.mark.asyncio
     async def test_websocket_echo_server_integration(self):
         """Test integration with WebSocket echo server for realistic WebSocket testing."""
         if not HAS_WEBSOCKETS:
@@ -365,7 +363,6 @@ class TestServiceContainerIntegration:
                 await websocket_connection.close()
                 logger.info("WebSocket connection closed.")
 
-    @pytest.mark.asyncio
     async def test_candles_feed_with_redis_state_management(
         self, redis_client, mock_server_with_caching
     ):
@@ -424,7 +421,6 @@ class TestServiceContainerIntegration:
         # Clean up
         await redis_client.delete(feed_state_key)
 
-    @pytest.mark.asyncio
     async def test_service_container_health_monitoring(self, redis_client):
         """Test monitoring and health checking of service containers."""
         if not HAS_REDIS:
@@ -471,7 +467,6 @@ class TestServiceContainerIntegration:
 
         logger.info("Service container health monitoring test passed")
 
-    @pytest.mark.asyncio
     async def test_integration_with_fallback_handling(self):
         """Test that integration tests gracefully handle missing service containers."""
         logger.info("Testing graceful fallback when service containers are not available")
@@ -506,7 +501,6 @@ class TestServiceContainerIntegration:
 
         logger.info("Integration test with fallback handling completed successfully")
 
-    @pytest.mark.asyncio
     async def test_concurrent_service_access(self, redis_client):
         """Test concurrent access to service containers."""
         if not HAS_REDIS:

--- a/tests/integration/test_testnet_support.py
+++ b/tests/integration/test_testnet_support.py
@@ -18,7 +18,6 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.skip(reason="Requires network connection to Binance testnet")
-@pytest.mark.asyncio
 async def test_binance_testnet_rest():
     """Test that Binance testnet works with REST strategy."""
     # Create a feed with testnet configuration
@@ -53,7 +52,6 @@ async def test_binance_testnet_rest():
 
 
 @pytest.mark.skip(reason="Requires network connection to Binance testnet")
-@pytest.mark.asyncio
 async def test_binance_testnet_ws():
     """Test that Binance testnet works with WebSocket strategy."""
     # Create a feed with testnet configuration
@@ -81,7 +79,6 @@ async def test_binance_testnet_ws():
 
 
 @pytest.mark.skip(reason="Requires network connection to Binance")
-@pytest.mark.asyncio
 async def test_binance_hybrid_mode():
     """Test that hybrid mode works correctly."""
     # Create a hybrid config that uses testnet for orders but production for candles

--- a/tests/live/test_rest_smoke.py
+++ b/tests/live/test_rest_smoke.py
@@ -55,7 +55,6 @@ def _connector_id(val):
 
 
 @pytest.mark.live
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "registry_key,trading_pair,interval,min_candles",
     CONNECTOR_TEST_CASES,
@@ -118,28 +117,17 @@ async def test_rest_fetch_candles(
         assert candle.close > 0, f"{prefix}: close={candle.close} not positive"
 
         # OHLC consistency
-        assert candle.high >= candle.low, (
-            f"{prefix}: high={candle.high} < low={candle.low}"
-        )
-        assert candle.high >= candle.open, (
-            f"{prefix}: high={candle.high} < open={candle.open}"
-        )
-        assert candle.high >= candle.close, (
-            f"{prefix}: high={candle.high} < close={candle.close}"
-        )
-        assert candle.low <= candle.open, (
-            f"{prefix}: low={candle.low} > open={candle.open}"
-        )
-        assert candle.low <= candle.close, (
-            f"{prefix}: low={candle.low} > close={candle.close}"
-        )
+        assert candle.high >= candle.low, f"{prefix}: high={candle.high} < low={candle.low}"
+        assert candle.high >= candle.open, f"{prefix}: high={candle.high} < open={candle.open}"
+        assert candle.high >= candle.close, f"{prefix}: high={candle.high} < close={candle.close}"
+        assert candle.low <= candle.open, f"{prefix}: low={candle.low} > open={candle.open}"
+        assert candle.low <= candle.close, f"{prefix}: low={candle.low} > close={candle.close}"
 
         # Volume: non-negative (Aevo returns 0 for mark-price-only data)
         assert candle.volume >= 0, f"{prefix}: volume={candle.volume} negative"
 
 
 @pytest.mark.live
-@pytest.mark.asyncio
 async def test_all_connectors_registered():
     """Verify all expected connectors are in the ExchangeRegistry."""
     registered = ExchangeRegistry.get_registered_exchanges()
@@ -150,7 +138,6 @@ async def test_all_connectors_registered():
 
 
 @pytest.mark.live
-@pytest.mark.asyncio
 async def test_factory_roundtrip():
     """Verify CandlesFactory can create adapters for all hummingbot connector names."""
     from candles_feed.hb_compat.data_types import CandlesConfig

--- a/tests/load/test_load_scenarios.py
+++ b/tests/load/test_load_scenarios.py
@@ -224,7 +224,6 @@ async def mock_server():
     await server.stop()
 
 
-@pytest.mark.asyncio
 async def test_basic_load_klines(mock_server):
     """Test basic load on the klines endpoint."""
     async with CandlesFeedLoadTester(mock_server) as tester:
@@ -242,7 +241,6 @@ async def test_basic_load_klines(mock_server):
         assert summary["requests_per_second"] > 10, f"RPS too low: {summary['requests_per_second']}"
 
 
-@pytest.mark.asyncio
 async def test_server_endpoints_load(mock_server):
     """Test load on basic server endpoints."""
     async with CandlesFeedLoadTester(mock_server) as tester:
@@ -259,7 +257,6 @@ async def test_server_endpoints_load(mock_server):
         )
 
 
-@pytest.mark.asyncio
 async def test_mixed_workload(mock_server):
     """Test mixed workload scenario."""
     async with CandlesFeedLoadTester(mock_server) as tester:

--- a/tests/performance/test_benchmarks.py
+++ b/tests/performance/test_benchmarks.py
@@ -27,7 +27,6 @@ from candles_feed.utils.profiling import BenchmarkSuite, PerformanceProfiler, pr
 class TestNetworkClientPerformance:
     """Performance tests for NetworkClient connection pooling and optimization."""
 
-    @pytest.mark.asyncio
     async def test_connection_pool_reuse(self, unused_tcp_port):
         """Test that connection pooling reduces connection establishment overhead."""
         config = NetworkConfig(connection_pool_size=50, enable_connection_pooling=True)
@@ -72,7 +71,6 @@ class TestNetworkClientPerformance:
             await network_client.close()
             await server.stop()
 
-    @pytest.mark.asyncio
     async def test_concurrent_request_performance(self, unused_tcp_port):
         """Test performance under concurrent load."""
         config = NetworkConfig(rest_api_timeout=10.0)
@@ -235,7 +233,6 @@ class TestDataProcessorPerformance:
 class TestAdapterPerformance:
     """Performance tests for adapter implementations."""
 
-    @pytest.mark.asyncio
     async def test_mock_adapter_throughput(self):
         """Test mock adapter performance to establish baseline."""
         config = NetworkConfig()
@@ -269,7 +266,6 @@ class TestAdapterPerformance:
         finally:
             await network_client.close()
 
-    @pytest.mark.asyncio
     async def test_memory_usage_scaling(self):
         """Test memory usage scaling with number of candles."""
         config = NetworkConfig()
@@ -322,7 +318,6 @@ class TestAdapterPerformance:
 class TestIntegrationPerformance:
     """End-to-end performance tests."""
 
-    @pytest.mark.asyncio
     async def test_multiple_adapters_concurrent(self):
         """Test performance with multiple adapters running concurrently."""
         config = NetworkConfig(connection_pool_size=200)
@@ -378,7 +373,6 @@ class TestIntegrationPerformance:
         finally:
             await network_client.close()
 
-    @pytest.mark.asyncio
     async def test_sustained_load_performance(self):
         """Test performance under sustained load to detect memory leaks."""
         config = NetworkConfig()

--- a/tests/unit/adapters/ascend_ex/test_ascend_ex_spot_adapter.py
+++ b/tests/unit/adapters/ascend_ex/test_ascend_ex_spot_adapter.py
@@ -136,7 +136,6 @@ class TestAscendExSpotAdapter(BaseAdapterTest):
         # Test with lowercase
         assert adapter.get_trading_pair_format("btc-usdt") == "btc/usdt"
 
-    @pytest.mark.asyncio
     async def test_fetch_rest_candles_custom(self, adapter, trading_pair, interval):
         """Custom async test for fetch_rest_candles."""
         # Create a mock network client

--- a/tests/unit/adapters/base_adapter_test.py
+++ b/tests/unit/adapters/base_adapter_test.py
@@ -267,7 +267,6 @@ class BaseAdapterTest(abc.ABC):
             args, kwargs = mock_get.call_args
             assert args[0] == adapter._get_rest_url()
 
-    @pytest.mark.asyncio
     async def test_fetch_rest_candles_async(self, adapter, trading_pair, interval):
         """Test fetch_rest_candles async method (for AsyncOnlyAdapter adapters)."""
         # Skip test for SyncOnlyAdapter adapters

--- a/tests/unit/adapters/binance/test_binance_perpetual_adapter.py
+++ b/tests/unit/adapters/binance/test_binance_perpetual_adapter.py
@@ -146,7 +146,6 @@ class TestBinancePerpetualAdapter(BaseAdapterTest):
         # Convert from exchange format (should be in seconds)
         assert adapter.ensure_timestamp_in_seconds(timestamp_ms) == timestamp_seconds
 
-    @pytest.mark.asyncio
     async def test_fetch_rest_candles_custom(self, adapter, trading_pair, interval):
         """Custom async test for fetch_rest_candles."""
         # Create a mock network client

--- a/tests/unit/adapters/binance/test_binance_spot_adapter.py
+++ b/tests/unit/adapters/binance/test_binance_spot_adapter.py
@@ -160,7 +160,6 @@ class TestBinanceSpotAdapter(BaseAdapterTest):
         # Test with lowercase
         assert adapter.get_trading_pair_format("btc-usdt") == "btcusdt"
 
-    @pytest.mark.asyncio
     async def test_fetch_rest_candles_custom(self, adapter, trading_pair, interval):
         """Custom async test for fetch_rest_candles."""
         # Create a mock network client

--- a/tests/unit/adapters/bybit/test_bybit_perpetual_adapter.py
+++ b/tests/unit/adapters/bybit/test_bybit_perpetual_adapter.py
@@ -144,7 +144,6 @@ class TestBybitPerpetualAdapter(BaseAdapterTest):
         """Test category param retrieval."""
         assert adapter.get_category_param() == "linear"
 
-    @pytest.mark.asyncio
     async def test_fetch_rest_candles_async(self, adapter, trading_pair, interval):
         """Custom async test for fetch_rest_candles."""
         # Create a mock network client

--- a/tests/unit/adapters/bybit/test_bybit_spot_adapter.py
+++ b/tests/unit/adapters/bybit/test_bybit_spot_adapter.py
@@ -146,7 +146,6 @@ class TestBybitSpotAdapter(BaseAdapterTest):
         # Bybit spot uses "spot" as category
         assert adapter.get_category_param() == "spot"
 
-    @pytest.mark.asyncio
     async def test_fetch_rest_candles_custom(self, adapter, trading_pair, interval):
         """Custom async test for fetch_rest_candles."""
         # Create a mock network client

--- a/tests/unit/adapters/ccxt/test_ccxt_base_adapter.py
+++ b/tests/unit/adapters/ccxt/test_ccxt_base_adapter.py
@@ -192,7 +192,6 @@ class TestCCXTBaseAdapter:
             adapter.parse_ws_message({})
 
     @patch("ccxt.binance")
-    @pytest.mark.asyncio
     async def test_fetch_rest_candles_async_wrapper(self, mock_binance):
         """Test async fetch_rest_candles wraps synchronous method."""
         # Setup

--- a/tests/unit/adapters/coinbase_advanced_trade/test_coinbase_advanced_trade_base_adapter.py
+++ b/tests/unit/adapters/coinbase_advanced_trade/test_coinbase_advanced_trade_base_adapter.py
@@ -169,7 +169,6 @@ class TestCoinbaseAdvancedTradeBaseAdapter(BaseAdapterTest):
         result = adapter.ensure_timestamp_in_seconds(test_data.get("timestamp"))
         assert result == timestamp
 
-    @pytest.mark.asyncio
     @patch.object(ConcreteCoinbaseAdvancedTradeAdapter, "_get_rest_url")
     async def test_fetch_rest_candles_custom(
         self, mock_get_rest_url, adapter, trading_pair, interval

--- a/tests/unit/adapters/coinbase_advanced_trade/test_coinbase_advanced_trade_spot_adapter.py
+++ b/tests/unit/adapters/coinbase_advanced_trade/test_coinbase_advanced_trade_spot_adapter.py
@@ -176,7 +176,6 @@ class TestCoinbaseAdvancedTradeSpotAdapter(BaseAdapterTest):
         result = adapter.ensure_timestamp_in_seconds(test_data.get("timestamp"))
         assert result == timestamp
 
-    @pytest.mark.asyncio
     @patch.object(CoinbaseAdvancedTradeSpotAdapter, "_get_rest_url")
     async def test_fetch_rest_candles_custom(
         self, mock_get_rest_url, adapter, trading_pair, interval

--- a/tests/unit/adapters/gate_io/test_gate_io_perpetual_adapter.py
+++ b/tests/unit/adapters/gate_io/test_gate_io_perpetual_adapter.py
@@ -132,7 +132,6 @@ class TestGateIoPerpetualAdapter(BaseAdapterTest):
         """Test Gate.io channel name getter."""
         assert adapter.get_channel_name() == PERPETUAL_CHANNEL_NAME
 
-    @pytest.mark.asyncio
     async def test_fetch_rest_candles_async(self, adapter, trading_pair, interval):
         """Test fetch_rest_candles async method."""
         # Create a mock network client

--- a/tests/unit/adapters/gate_io/test_gate_io_spot_adapter.py
+++ b/tests/unit/adapters/gate_io/test_gate_io_spot_adapter.py
@@ -150,7 +150,6 @@ class TestGateIoSpotAdapter(BaseAdapterTest):
         """Test Gate.io channel name getter."""
         assert adapter.get_channel_name() == SPOT_CHANNEL_NAME
 
-    @pytest.mark.asyncio
     async def test_fetch_rest_candles_async(self, adapter, trading_pair, interval):
         """Test fetch_rest_candles async method."""
         # Create a mock network client

--- a/tests/unit/adapters/hyperliquid/test_hyperliquid_perpetual_adapter.py
+++ b/tests/unit/adapters/hyperliquid/test_hyperliquid_perpetual_adapter.py
@@ -111,7 +111,6 @@ class TestHyperliquidPerpetualAdapter(BaseAdapterTest):
         assert adapter.get_supported_intervals() == INTERVALS
         assert adapter.get_ws_supported_intervals() == WS_INTERVALS
 
-    @pytest.mark.asyncio
     async def test_hyperliquid_error_handling(self, adapter):
         """Test HyperLiquid-specific error handling."""
         # Create a mock network client

--- a/tests/unit/adapters/hyperliquid/test_hyperliquid_spot_adapter.py
+++ b/tests/unit/adapters/hyperliquid/test_hyperliquid_spot_adapter.py
@@ -96,7 +96,6 @@ class TestHyperliquidSpotAdapter(BaseAdapterTest):
         # Test with multiple hyphens
         assert adapter.get_trading_pair_format("ETH-BTC-PERP") == "ETH"
 
-    @pytest.mark.asyncio
     async def test_hyperliquid_rest_get_implementation(self, adapter):
         """Test HyperLiquid's fetch_rest_candles implementation."""
         # Create a mock network client

--- a/tests/unit/adapters/kraken/test_kraken_spot_adapter.py
+++ b/tests/unit/adapters/kraken/test_kraken_spot_adapter.py
@@ -244,7 +244,6 @@ class TestKrakenSpotAdapter(BaseAdapterTest):
         assert adapter.convert_timestamp_to_exchange(timestamp_seconds) == timestamp_seconds
 
     # Override the BaseAdapterTest method for async test
-    @pytest.mark.asyncio
     async def test_fetch_rest_candles_async(self, adapter, trading_pair, interval):
         """Custom test for fetch_rest_candles_async for Kraken."""
         # Skip test for SyncOnlyAdapter adapters

--- a/tests/unit/adapters/kucoin/test_kucoin_perpetual_adapter.py
+++ b/tests/unit/adapters/kucoin/test_kucoin_perpetual_adapter.py
@@ -288,7 +288,6 @@ class TestKucoinPerpetualAdapter(BaseAdapterTest):
         assert ws_intervals == ["1m"]
 
     # Override the BaseAdapterTest method for async test
-    @pytest.mark.asyncio
     async def test_fetch_rest_candles_async(self, adapter, trading_pair, interval):
         """Custom test for fetch_rest_candles_async for KuCoin perpetual."""
         # Skip test for SyncOnlyAdapter adapters

--- a/tests/unit/adapters/kucoin/test_kucoin_spot_adapter.py
+++ b/tests/unit/adapters/kucoin/test_kucoin_spot_adapter.py
@@ -258,7 +258,6 @@ class TestKucoinSpotAdapter(BaseAdapterTest):
         assert ws_intervals == ["1m"]
 
     # Override the BaseAdapterTest method for async test
-    @pytest.mark.asyncio
     async def test_fetch_rest_candles_async(self, adapter, trading_pair, interval):
         """Custom test for fetch_rest_candles_async for KuCoin."""
         # Skip test for SyncOnlyAdapter adapters

--- a/tests/unit/adapters/mexc/test_mexc_perpetual_adapter.py
+++ b/tests/unit/adapters/mexc/test_mexc_perpetual_adapter.py
@@ -270,7 +270,6 @@ class TestMEXCPerpetualAdapter(BaseAdapterTest):
         assert adapter.ensure_timestamp_in_seconds(timestamp_seconds) == timestamp_seconds
         assert adapter.ensure_timestamp_in_seconds(timestamp_seconds * 1000) == timestamp_seconds
 
-    @pytest.mark.asyncio
     async def test_fetch_rest_candles_async(self, adapter, trading_pair, interval):
         """Test fetch_rest_candles async method for MEXCPerpetualAdapter."""
         # Skip test for SyncOnlyAdapter adapters

--- a/tests/unit/adapters/mexc/test_mexc_spot_adapter.py
+++ b/tests/unit/adapters/mexc/test_mexc_spot_adapter.py
@@ -253,7 +253,6 @@ class TestMEXCSpotAdapter(BaseAdapterTest):
         assert adapter.ensure_timestamp_in_seconds(timestamp_seconds * 1000) == timestamp_seconds
         assert adapter.ensure_timestamp_in_seconds(timestamp_seconds) == timestamp_seconds
 
-    @pytest.mark.asyncio
     async def test_fetch_rest_candles_async(self, adapter, trading_pair, interval):
         """Test fetch_rest_candles async method for MEXCSpotAdapter."""
         # Skip test for SyncOnlyAdapter adapters

--- a/tests/unit/adapters/okx/test_okx_base_adapter.py
+++ b/tests/unit/adapters/okx/test_okx_base_adapter.py
@@ -152,7 +152,6 @@ class TestOKXBaseAdapter(BaseAdapterTest):
         # Convert from exchange format (should be in seconds)
         assert adapter.ensure_timestamp_in_seconds(timestamp_ms) == timestamp_seconds
 
-    @pytest.mark.asyncio
     async def test_fetch_rest_candles_custom(self, adapter, trading_pair, interval):
         """Custom async test for fetch_rest_candles."""
         # Create a mock network client

--- a/tests/unit/adapters/okx/test_okx_perpetual_adapter.py
+++ b/tests/unit/adapters/okx/test_okx_perpetual_adapter.py
@@ -156,7 +156,6 @@ class TestOKXPerpetualAdapter(BaseAdapterTest):
         # If already has SWAP suffix, should return as is
         assert adapter.get_trading_pair_format("BTC-USDT-SWAP") == "BTC-USDT-SWAP"
 
-    @pytest.mark.asyncio
     async def test_fetch_rest_candles_custom(self, adapter, trading_pair, interval):
         """Custom async test for fetch_rest_candles."""
         # Create a mock network client

--- a/tests/unit/adapters/okx/test_okx_spot_adapter.py
+++ b/tests/unit/adapters/okx/test_okx_spot_adapter.py
@@ -142,7 +142,6 @@ class TestOKXSpotAdapter(BaseAdapterTest):
         assert adapter.get_trading_pair_format("BTC-USDT") == "BTC-USDT"
         assert adapter.get_trading_pair_format("ETH-BTC") == "ETH-BTC"
 
-    @pytest.mark.asyncio
     async def test_fetch_rest_candles_custom(self, adapter, trading_pair, interval):
         """Custom async test for fetch_rest_candles."""
         # Create a mock network client

--- a/tests/unit/adapters/test_adapter_mixins.py
+++ b/tests/unit/adapters/test_adapter_mixins.py
@@ -224,7 +224,6 @@ class TestSyncOnlyAdapter:
             assert candles[0].timestamp == 1620000000
             assert candles[0].open == 100.0
 
-    @pytest.mark.asyncio
     async def test_sync_adapter_async_wrapper(self):
         """Test that the async wrapper calls the synchronous method correctly."""
         adapter = self.MockSyncAdapter()
@@ -261,7 +260,6 @@ class TestSyncOnlyAdapter:
         assert result[0].timestamp == 1620000000
         assert result[0].open == 100.0
 
-    @pytest.mark.asyncio
     async def test_sync_adapter_ignores_network_client(self):
         """Test that SyncOnlyAdapter ignores the network_client parameter."""
         adapter = self.MockSyncAdapter()
@@ -477,7 +475,6 @@ class TestAsyncOnlyAdapter:
         with pytest.raises(NotImplementedError):
             adapter.fetch_rest_candles_synchronous(trading_pair="BTC-USDT", interval="1m")
 
-    @pytest.mark.asyncio
     async def test_async_adapter_implementation(self):
         """Test that the async implementation works correctly."""
         adapter = self.MockAsyncAdapter()
@@ -498,7 +495,6 @@ class TestAsyncOnlyAdapter:
         assert result[0].timestamp == 1620000000
         assert result[0].open == 100.0
 
-    @pytest.mark.asyncio
     async def test_async_adapter_with_network_client(self):
         """Test that AsyncOnlyAdapter uses the network_client if provided."""
         adapter = self.MockAsyncAdapter()

--- a/tests/unit/adapters/test_base_adapter.py
+++ b/tests/unit/adapters/test_base_adapter.py
@@ -406,7 +406,6 @@ class TestBaseAdapter:
         candles = adapter._parse_rest_response({"not": "a list"})
         assert candles == []
 
-    @pytest.mark.asyncio
     async def test_fetch_rest_candles(self):
         """Test fetching REST candles."""
         adapter = self.ConcreteAdapter()
@@ -425,7 +424,6 @@ class TestBaseAdapter:
         assert call["limit"] == 500
         assert call["network_client"] is None
 
-    @pytest.mark.asyncio
     async def test_fetch_rest_candles_with_network_client(self):
         """Test fetching REST candles with network client."""
         adapter = self.ConcreteAdapter()

--- a/tests/unit/core/test_candles_feed.py
+++ b/tests/unit/core/test_candles_feed.py
@@ -106,7 +106,6 @@ class TestCandlesFeed:
 
             return feed
 
-    @pytest.mark.asyncio
     async def test_initialization(self, mock_exchange_registry):
         """Test CandlesFeed initialization."""
         feed = CandlesFeed(
@@ -126,7 +125,6 @@ class TestCandlesFeed:
         assert feed._candles.maxlen == 100
         assert feed._active is False
 
-    @pytest.mark.asyncio
     async def test_start_with_websocket(self, candles_feed):
         """Test starting the feed with WebSocket strategy."""
         # Patch internal CandlesFeed methods to avoid real network calls
@@ -144,7 +142,6 @@ class TestCandlesFeed:
             assert candles_feed._active is True
             assert candles_feed._using_ws is True
 
-    @pytest.mark.asyncio
     async def test_start_with_rest(self, candles_feed):
         """Test starting the feed with REST strategy."""
         # Patch internal CandlesFeed methods to avoid real network calls
@@ -159,7 +156,6 @@ class TestCandlesFeed:
             assert candles_feed._active is True
             assert candles_feed._using_ws is False
 
-    @pytest.mark.asyncio
     async def test_start_with_auto_strategy_ws_available(self, candles_feed):
         """Test auto strategy selection when WS is available."""
         # Patch internal CandlesFeed methods to avoid real network calls
@@ -176,7 +172,6 @@ class TestCandlesFeed:
             # Verify WebSocket was chosen
             assert candles_feed._using_ws is True
 
-    @pytest.mark.asyncio
     async def test_start_with_auto_strategy_ws_unavailable(self, candles_feed):
         """Test auto strategy selection when WS is unavailable."""
         # Patch internal CandlesFeed methods to avoid real network calls
@@ -195,7 +190,6 @@ class TestCandlesFeed:
             # Verify REST was chosen
             assert candles_feed._using_ws is False
 
-    @pytest.mark.asyncio
     async def test_stop(self, candles_feed):
         """Test stopping the feed."""
         # Patch the stop method to avoid real network calls
@@ -210,7 +204,6 @@ class TestCandlesFeed:
             # Verify feed state after stopping
             assert candles_feed._active is False
 
-    @pytest.mark.asyncio
     async def test_get_candles(self, candles_feed):
         """Test getting candles."""
         # Create some test candles
@@ -240,7 +233,6 @@ class TestCandlesFeed:
         assert candles[0].timestamp == base_time
         assert candles[1].timestamp == base_time + 60
 
-    @pytest.mark.asyncio
     async def test_fetch_candles(self, candles_feed):
         """Test fetching historical candles."""
         # Setup test data
@@ -280,7 +272,6 @@ class TestCandlesFeed:
             # Verify the candles were added
             assert len(candles_feed._candles) == 2
 
-    @pytest.mark.asyncio
     async def test_fetch_candles_with_limit(self, candles_feed):
         """Test fetching historical candles."""
         # Setup test data
@@ -320,7 +311,6 @@ class TestCandlesFeed:
             # Verify the candles were added
             assert len(candles_feed._candles) == 2
 
-    @pytest.mark.asyncio
     async def test_add_candle(self, candles_feed):
         """Test adding a single candle."""
         # Create a test candle
@@ -351,7 +341,6 @@ class TestCandlesFeed:
         feed_5m = CandlesFeed(exchange="binance_spot", trading_pair="BTC-USDT", interval="5m")
         assert feed_5m.interval_in_seconds == 300
 
-    @pytest.mark.asyncio
     async def test_max_records_limit(self, candles_feed):
         """Test the max records limit is enforced."""
         # Set a small max records limit

--- a/tests/unit/core/test_metrics.py
+++ b/tests/unit/core/test_metrics.py
@@ -162,7 +162,6 @@ class TestPerformanceTracker:
             assert tracker.collector.metrics.total_requests == 1
             assert tracker.collector.metrics.failed_requests == 1
 
-    @pytest.mark.asyncio
     async def test_track_stream_context_manager(self):
         """Test stream tracking context manager."""
         tracker = PerformanceTracker()
@@ -200,7 +199,6 @@ class TestTrackingOperations:
         metrics = collector.monitoring.get_metrics()
         assert "operation_test_operation_duration" in metrics
 
-    @pytest.mark.asyncio
     async def test_track_async_operation_success(self):
         """Test track_async_operation context manager with success."""
         collector = MetricsCollector()

--- a/tests/unit/core/test_network_strategies.py
+++ b/tests/unit/core/test_network_strategies.py
@@ -64,7 +64,6 @@ def mock_logger():
     return MagicMock(logging.Logger)
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "candles, expected_candles",
     [
@@ -126,7 +125,6 @@ async def test_ws_strategy_poll_once(
     )
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "test_id, initial_candles, expected_candles",
     [
@@ -230,7 +228,6 @@ async def test_listen_for_updates(
         initialize_candles_mock.assert_awaited_once()
 
 
-@pytest.mark.asyncio
 async def test_initialize_candles_success(
     mock_network_client,
     mock_adapter,
@@ -268,7 +265,6 @@ async def test_initialize_candles_success(
     )
 
 
-@pytest.mark.asyncio
 async def test_initialize_candles_failure(
     mock_network_client,
     mock_adapter,
@@ -299,7 +295,6 @@ async def test_initialize_candles_failure(
     mock_logger.warning.assert_called_once_with("Failed to initialize candles, will retry")
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "test_id, new_candles, expected_calls",
     [
@@ -350,7 +345,6 @@ async def test_update_candles_ws_strategy(
 # These fixtures are already defined above, so we don't need to redefine them
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "test_id, start_time, end_time, limit",
     [
@@ -475,7 +469,6 @@ async def test_rest_strategy_poll_once(
     )
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "test_id, initial_candles",
     [
@@ -610,7 +603,6 @@ async def test_poll_for_updates(
             )
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "test_id, new_candles, expected_calls",
     [

--- a/tests/unit/core/test_repository_insights.py
+++ b/tests/unit/core/test_repository_insights.py
@@ -38,7 +38,6 @@ def collector():
 
 
 class TestRepositoryInsightsCollector:
-    @pytest.mark.asyncio
     async def test_init(self, collector):
         assert collector.repo_owner == REPO_OWNER
         assert collector.repo_name == REPO_NAME
@@ -46,7 +45,6 @@ class TestRepositoryInsightsCollector:
         assert "Authorization" in collector.headers
         assert collector.headers["Authorization"] == f"Bearer {MOCK_TOKEN}"
 
-    @pytest.mark.asyncio
     async def test_make_request_success(self, collector):
         with aioresponses() as m:
             url = f"{collector.BASE_URL}/test_endpoint"
@@ -58,7 +56,6 @@ class TestRepositoryInsightsCollector:
             assert result == {"data": "success"}
             m.assert_called_once_with(url, params=None, headers=collector.headers)
 
-    @pytest.mark.asyncio
     async def test_make_request_http_error(self, collector):
         with aioresponses() as m:
             url = f"{collector.BASE_URL}/test_endpoint"
@@ -70,7 +67,6 @@ class TestRepositoryInsightsCollector:
 
             assert excinfo.value.status == 404
 
-    @pytest.mark.asyncio
     async def test_fetch_paginated_data_success(self, collector):
         endpoint = "/paginated_endpoint"
         base_url = collector.BASE_URL
@@ -94,7 +90,6 @@ class TestRepositoryInsightsCollector:
             # Example: Check call count if needed, though specific params are checked by matching URLs
             assert len(m.requests) == 2
 
-    @pytest.mark.asyncio
     async def test_get_issue_metrics_basic(self, collector):
         async with aiohttp.ClientSession() as session:  # Create a real session
             now = datetime.now(timezone.utc)
@@ -181,7 +176,6 @@ class TestRepositoryInsightsCollector:
             assert call_args2.args[2] is session  # client
             assert call_args2.kwargs == {}
 
-    @pytest.mark.asyncio
     async def test_get_pull_request_metrics_stubbed(self, collector):
         async with aiohttp.ClientSession() as session:  # Create a real session
             # Currently stubbed, so it should return default PullRequestMetrics
@@ -191,7 +185,6 @@ class TestRepositoryInsightsCollector:
             assert isinstance(metrics, PullRequestMetrics)
             assert metrics.total_open_prs == 0  # Default value
 
-    @pytest.mark.asyncio
     async def test_get_commit_activity_success(self, collector):
         async with aiohttp.ClientSession() as session:  # Create a real session
             mock_activity_data = [
@@ -212,7 +205,6 @@ class TestRepositoryInsightsCollector:
         assert metrics.commits_last_30_days == (10 + 15 + 5 + 20)
         assert metrics.commit_frequency_per_week == (10 + 15 + 5 + 20) / 4
 
-    @pytest.mark.asyncio
     async def test_get_commit_activity_empty_or_error(self, collector):
         url = f"{collector.BASE_URL}/repos/{REPO_OWNER}/{REPO_NAME}/stats/commit_activity"
 
@@ -237,7 +229,6 @@ class TestRepositoryInsightsCollector:
                 metrics = await collector.get_commit_activity(client=session)
                 assert metrics.commits_last_7_days == 0
 
-    @pytest.mark.asyncio
     async def test_get_release_metrics_success(self, collector):
         async with aiohttp.ClientSession() as session:  # Create a real session
             now = datetime.now(timezone.utc).replace(
@@ -265,7 +256,6 @@ class TestRepositoryInsightsCollector:
         expected_avg_days = (30 + 60) / 2.0
         assert metrics.average_time_between_releases_days == pytest.approx(expected_avg_days)
 
-    @pytest.mark.asyncio
     async def test_get_contributor_stats_success(self, collector):
         async with aiohttp.ClientSession() as session:  # Create a real session
             now_utc = datetime.now(timezone.utc)
@@ -348,7 +338,6 @@ class TestRepositoryInsightsCollector:
         assert ci_snapshot_none is None
         assert cq_snapshot_none is None
 
-    @pytest.mark.asyncio
     async def test_collect_all_metrics_success(self, collector):
         # Mock all get_* methods
         with (
@@ -409,7 +398,6 @@ class TestRepositoryInsightsCollector:
             m_community.assert_called_once()
             m_parse_qg.assert_called_once_with(quality_data)
 
-    @pytest.mark.asyncio
     async def test_collect_all_metrics_partial_failure(self, collector, caplog):
         with (
             patch.object(

--- a/tests/unit/core/test_server_with_plugin.py
+++ b/tests/unit/core/test_server_with_plugin.py
@@ -46,7 +46,6 @@ async def client(aiohttp_client, binance_server):
     return client
 
 
-@pytest.mark.asyncio
 async def test_server_uses_plugin_rate_limits(client, binance_server):
     """Test that the server uses rate limits from the plugin."""
     # Get the rate limits from the server
@@ -71,7 +70,6 @@ async def test_server_uses_plugin_rate_limits(client, binance_server):
     assert response.status == 200
 
 
-@pytest.mark.asyncio
 async def test_server_uses_plugin_api_keys(client, binance_server):
     """Test that the server uses API keys from the plugin."""
     # Get the API keys from the server
@@ -93,7 +91,6 @@ async def test_server_uses_plugin_api_keys(client, binance_server):
     assert response.status != 401
 
 
-@pytest.mark.asyncio
 async def test_network_conditions_simulation(client, binance_server):
     """Test that the server can simulate network conditions."""
     # First test with no latency
@@ -114,7 +111,6 @@ async def test_network_conditions_simulation(client, binance_server):
     assert elapsed >= 0.2  # Should be at least 200ms
 
 
-@pytest.mark.asyncio
 async def test_url_patcher(binance_server):
     """Test that the URL patcher works correctly."""
     # Create a URL patcher

--- a/tests/unit/hb_compat/conftest.py
+++ b/tests/unit/hb_compat/conftest.py
@@ -19,7 +19,10 @@ def mock_exchange_registry():
         mock_adapter = MagicMock(spec=BaseAdapter)
         mock_adapter.get_trading_pair_format.return_value = "BTCUSDT"
         mock_adapter.get_supported_intervals.return_value = {
-            "1m": 60, "5m": 300, "15m": 900, "1h": 3600,
+            "1m": 60,
+            "5m": 300,
+            "15m": 900,
+            "1h": 3600,
         }
         mock_adapter.get_ws_supported_intervals.return_value = ["1m", "5m", "1h"]
         mock.return_value = mock_adapter

--- a/tests/unit/hb_compat/test_adapter.py
+++ b/tests/unit/hb_compat/test_adapter.py
@@ -30,30 +30,26 @@ class TestCandlesBaseAdapterProperties:
 
     def test_name_returns_exchange(self):
         from candles_feed.hb_compat.adapter import CandlesBaseAdapter
-        adapter = CandlesBaseAdapter(
-            exchange="binance", trading_pair="BTC-USDT", interval="1m"
-        )
+
+        adapter = CandlesBaseAdapter(exchange="binance", trading_pair="BTC-USDT", interval="1m")
         assert adapter.name == "binance"
 
     def test_interval_delegation(self):
         from candles_feed.hb_compat.adapter import CandlesBaseAdapter
-        adapter = CandlesBaseAdapter(
-            exchange="binance", trading_pair="BTC-USDT", interval="5m"
-        )
+
+        adapter = CandlesBaseAdapter(exchange="binance", trading_pair="BTC-USDT", interval="5m")
         assert adapter.interval == "5m"
 
     def test_max_records_delegation(self):
         from candles_feed.hb_compat.adapter import CandlesBaseAdapter
-        adapter = CandlesBaseAdapter(
-            exchange="binance", trading_pair="BTC-USDT", max_records=1000
-        )
+
+        adapter = CandlesBaseAdapter(exchange="binance", trading_pair="BTC-USDT", max_records=1000)
         assert adapter.max_records == 1000
 
     def test_ready_delegation(self):
         from candles_feed.hb_compat.adapter import CandlesBaseAdapter
-        adapter = CandlesBaseAdapter(
-            exchange="binance", trading_pair="BTC-USDT", max_records=2
-        )
+
+        adapter = CandlesBaseAdapter(exchange="binance", trading_pair="BTC-USDT", max_records=2)
         assert adapter.ready is False
         adapter._feed.add_candle(_make_candle(1000))
         adapter._feed.add_candle(_make_candle(1060))
@@ -61,38 +57,41 @@ class TestCandlesBaseAdapterProperties:
 
     def test_candles_df_is_property_not_method(self):
         from candles_feed.hb_compat.adapter import CandlesBaseAdapter
-        adapter = CandlesBaseAdapter(
-            exchange="binance", trading_pair="BTC-USDT"
-        )
+
+        adapter = CandlesBaseAdapter(exchange="binance", trading_pair="BTC-USDT")
         df = adapter.candles_df
         assert isinstance(df, pd.DataFrame)
 
     def test_candles_df_has_correct_columns(self):
         from candles_feed.hb_compat.adapter import CandlesBaseAdapter
-        adapter = CandlesBaseAdapter(
-            exchange="binance", trading_pair="BTC-USDT", max_records=2
-        )
+
+        adapter = CandlesBaseAdapter(exchange="binance", trading_pair="BTC-USDT", max_records=2)
         adapter._feed.add_candle(_make_candle(1000))
         df = adapter.candles_df
         expected_columns = [
-            "timestamp", "open", "high", "low", "close", "volume",
-            "quote_asset_volume", "n_trades",
-            "taker_buy_base_volume", "taker_buy_quote_volume",
+            "timestamp",
+            "open",
+            "high",
+            "low",
+            "close",
+            "volume",
+            "quote_asset_volume",
+            "n_trades",
+            "taker_buy_base_volume",
+            "taker_buy_quote_volume",
         ]
         assert list(df.columns) == expected_columns
 
     def test_interval_in_seconds(self):
         from candles_feed.hb_compat.adapter import CandlesBaseAdapter
-        adapter = CandlesBaseAdapter(
-            exchange="binance", trading_pair="BTC-USDT", interval="1m"
-        )
+
+        adapter = CandlesBaseAdapter(exchange="binance", trading_pair="BTC-USDT", interval="1m")
         assert adapter.interval_in_seconds == 60
 
     def test_get_exchange_trading_pair(self):
         from candles_feed.hb_compat.adapter import CandlesBaseAdapter
-        adapter = CandlesBaseAdapter(
-            exchange="binance", trading_pair="BTC-USDT"
-        )
+
+        adapter = CandlesBaseAdapter(exchange="binance", trading_pair="BTC-USDT")
         result = adapter.get_exchange_trading_pair("BTC-USDT")
         assert isinstance(result, str)
         assert len(result) > 0
@@ -104,36 +103,33 @@ class TestCandlesBaseAdapterProtocolConformance:
     def test_isinstance_check(self):
         from candles_feed.hb_compat.adapter import CandlesBaseAdapter
         from candles_feed.hb_compat.protocols import CandlesBaseProtocol
-        adapter = CandlesBaseAdapter(
-            exchange="binance", trading_pair="BTC-USDT"
-        )
+
+        adapter = CandlesBaseAdapter(exchange="binance", trading_pair="BTC-USDT")
         assert isinstance(adapter, CandlesBaseProtocol)
 
 
 class TestCandlesBaseAdapterLifecycle:
     """Test sync start/stop bridge."""
 
-    @pytest.mark.asyncio
     async def test_start_schedules_async_task(self):
         from candles_feed.hb_compat.adapter import CandlesBaseAdapter
-        adapter = CandlesBaseAdapter(
-            exchange="binance", trading_pair="BTC-USDT"
-        )
+
+        adapter = CandlesBaseAdapter(exchange="binance", trading_pair="BTC-USDT")
         with patch.object(adapter._feed, "start", new_callable=AsyncMock) as mock_start:
             adapter.start()
             import asyncio
+
             await asyncio.sleep(0.1)
             mock_start.assert_called_once()
 
-    @pytest.mark.asyncio
     async def test_stop_schedules_async_task(self):
         from candles_feed.hb_compat.adapter import CandlesBaseAdapter
-        adapter = CandlesBaseAdapter(
-            exchange="binance", trading_pair="BTC-USDT"
-        )
+
+        adapter = CandlesBaseAdapter(exchange="binance", trading_pair="BTC-USDT")
         with patch.object(adapter._feed, "stop", new_callable=AsyncMock) as mock_stop:
             adapter.stop()
             import asyncio
+
             await asyncio.sleep(0.1)
             mock_stop.assert_called_once()
 
@@ -141,12 +137,10 @@ class TestCandlesBaseAdapterLifecycle:
 class TestCandlesBaseAdapterDataConversion:
     """Test data format conversions."""
 
-    @pytest.mark.asyncio
     async def test_fetch_candles_returns_ndarray(self):
         from candles_feed.hb_compat.adapter import CandlesBaseAdapter
-        adapter = CandlesBaseAdapter(
-            exchange="binance", trading_pair="BTC-USDT"
-        )
+
+        adapter = CandlesBaseAdapter(exchange="binance", trading_pair="BTC-USDT")
         candles = [_make_candle(1000), _make_candle(1060)]
         with patch.object(
             adapter._feed, "fetch_candles", new_callable=AsyncMock, return_value=candles
@@ -156,38 +150,32 @@ class TestCandlesBaseAdapterDataConversion:
             assert result.shape == (2, 10)
             # Validate full column values for first row match _make_candle(1000, 100.0)
             row = result[0]
-            assert row[0] == 1000        # timestamp
-            assert row[1] == 100.0       # open
-            assert row[2] == 101.0       # high
-            assert row[3] == 99.0        # low
-            assert row[4] == 100.5       # close
-            assert row[5] == 1000.0      # volume
-            assert row[6] == 100000.0    # quote_asset_volume
-            assert row[7] == 50          # n_trades
-            assert row[8] == 500.0       # taker_buy_base_volume
-            assert row[9] == 50000.0     # taker_buy_quote_volume
+            assert row[0] == 1000  # timestamp
+            assert row[1] == 100.0  # open
+            assert row[2] == 101.0  # high
+            assert row[3] == 99.0  # low
+            assert row[4] == 100.5  # close
+            assert row[5] == 1000.0  # volume
+            assert row[6] == 100000.0  # quote_asset_volume
+            assert row[7] == 50  # n_trades
+            assert row[8] == 500.0  # taker_buy_base_volume
+            assert row[9] == 50000.0  # taker_buy_quote_volume
 
-    @pytest.mark.asyncio
     async def test_fetch_candles_none_limit_defaults_to_500(self):
         from candles_feed.hb_compat.adapter import CandlesBaseAdapter
-        adapter = CandlesBaseAdapter(
-            exchange="binance", trading_pair="BTC-USDT"
-        )
+
+        adapter = CandlesBaseAdapter(exchange="binance", trading_pair="BTC-USDT")
         with patch.object(
             adapter._feed, "fetch_candles", new_callable=AsyncMock, return_value=[]
         ) as mock_fetch:
             await adapter.fetch_candles(limit=None)
-            mock_fetch.assert_called_once_with(
-                start_time=None, end_time=None, limit=500
-            )
+            mock_fetch.assert_called_once_with(start_time=None, end_time=None, limit=500)
 
-    @pytest.mark.asyncio
     async def test_get_historical_candles_unpacks_config(self):
         from candles_feed.hb_compat.adapter import CandlesBaseAdapter
         from candles_feed.hb_compat.data_types import HistoricalCandlesConfig
-        adapter = CandlesBaseAdapter(
-            exchange="binance", trading_pair="BTC-USDT"
-        )
+
+        adapter = CandlesBaseAdapter(exchange="binance", trading_pair="BTC-USDT")
         config = HistoricalCandlesConfig(
             connector_name="binance",
             trading_pair="BTC-USDT",
@@ -206,15 +194,11 @@ class TestCandlesBaseAdapterDataConversion:
             mock_hist.assert_called_once_with(start_time=1000, end_time=2000)
             assert isinstance(result, pd.DataFrame)
 
-    @pytest.mark.asyncio
     async def test_fetch_candles_empty_returns_empty_ndarray(self):
         from candles_feed.hb_compat.adapter import CandlesBaseAdapter
-        adapter = CandlesBaseAdapter(
-            exchange="binance", trading_pair="BTC-USDT"
-        )
-        with patch.object(
-            adapter._feed, "fetch_candles", new_callable=AsyncMock, return_value=[]
-        ):
+
+        adapter = CandlesBaseAdapter(exchange="binance", trading_pair="BTC-USDT")
+        with patch.object(adapter._feed, "fetch_candles", new_callable=AsyncMock, return_value=[]):
             result = await adapter.fetch_candles(start_time=1000, end_time=1060)
             assert isinstance(result, np.ndarray)
             assert result.shape == (0, 10)
@@ -225,20 +209,29 @@ class TestCandlesBaseAdapterResetWithDataFrame:
 
     def test_reset_clears_and_repopulates(self):
         from candles_feed.hb_compat.adapter import CandlesBaseAdapter
-        adapter = CandlesBaseAdapter(
-            exchange="binance", trading_pair="BTC-USDT", max_records=10
-        )
+
+        adapter = CandlesBaseAdapter(exchange="binance", trading_pair="BTC-USDT", max_records=10)
         adapter._feed.add_candle(_make_candle(500))
         assert len(adapter._feed.get_candles()) == 1
 
-        df = pd.DataFrame([
-            [1000, 100.0, 101.0, 99.0, 100.5, 1000.0, 100000.0, 50, 500.0, 50000.0],
-            [1060, 101.0, 102.0, 100.0, 101.5, 1100.0, 110000.0, 55, 550.0, 55000.0],
-        ], columns=[
-            "timestamp", "open", "high", "low", "close", "volume",
-            "quote_asset_volume", "n_trades",
-            "taker_buy_base_volume", "taker_buy_quote_volume",
-        ])
+        df = pd.DataFrame(
+            [
+                [1000, 100.0, 101.0, 99.0, 100.5, 1000.0, 100000.0, 50, 500.0, 50000.0],
+                [1060, 101.0, 102.0, 100.0, 101.5, 1100.0, 110000.0, 55, 550.0, 55000.0],
+            ],
+            columns=[
+                "timestamp",
+                "open",
+                "high",
+                "low",
+                "close",
+                "volume",
+                "quote_asset_volume",
+                "n_trades",
+                "taker_buy_base_volume",
+                "taker_buy_quote_volume",
+            ],
+        )
         adapter.reset_with_dataframe(df)
 
         candles = adapter._feed.get_candles()
@@ -254,12 +247,14 @@ class TestCandlesBaseAdapterResetWithDataFrame:
 
     def test_reset_with_missing_optional_columns(self):
         from candles_feed.hb_compat.adapter import CandlesBaseAdapter
-        adapter = CandlesBaseAdapter(
-            exchange="binance", trading_pair="BTC-USDT", max_records=10
+
+        adapter = CandlesBaseAdapter(exchange="binance", trading_pair="BTC-USDT", max_records=10)
+        df = pd.DataFrame(
+            [
+                [1000, 100.0, 101.0, 99.0, 100.5, 1000.0],
+            ],
+            columns=["timestamp", "open", "high", "low", "close", "volume"],
         )
-        df = pd.DataFrame([
-            [1000, 100.0, 101.0, 99.0, 100.5, 1000.0],
-        ], columns=["timestamp", "open", "high", "low", "close", "volume"])
         adapter.reset_with_dataframe(df)
 
         candles = adapter._feed.get_candles()
@@ -273,16 +268,36 @@ class TestCandlesBaseAdapterResetWithDataFrame:
 
     def test_reset_with_nan_optional_columns(self):
         from candles_feed.hb_compat.adapter import CandlesBaseAdapter
-        adapter = CandlesBaseAdapter(
-            exchange="binance", trading_pair="BTC-USDT", max_records=10
+
+        adapter = CandlesBaseAdapter(exchange="binance", trading_pair="BTC-USDT", max_records=10)
+        df = pd.DataFrame(
+            [
+                [
+                    1000,
+                    100.0,
+                    101.0,
+                    99.0,
+                    100.5,
+                    1000.0,
+                    float("nan"),
+                    float("nan"),
+                    float("nan"),
+                    float("nan"),
+                ],
+            ],
+            columns=[
+                "timestamp",
+                "open",
+                "high",
+                "low",
+                "close",
+                "volume",
+                "quote_asset_volume",
+                "n_trades",
+                "taker_buy_base_volume",
+                "taker_buy_quote_volume",
+            ],
         )
-        df = pd.DataFrame([
-            [1000, 100.0, 101.0, 99.0, 100.5, 1000.0, float("nan"), float("nan"), float("nan"), float("nan")],
-        ], columns=[
-            "timestamp", "open", "high", "low", "close", "volume",
-            "quote_asset_volume", "n_trades",
-            "taker_buy_base_volume", "taker_buy_quote_volume",
-        ])
         adapter.reset_with_dataframe(df)
 
         candles = adapter._feed.get_candles()
@@ -295,9 +310,8 @@ class TestCandlesBaseAdapterResetWithDataFrame:
 
     def test_reset_with_empty_dataframe(self):
         from candles_feed.hb_compat.adapter import CandlesBaseAdapter
-        adapter = CandlesBaseAdapter(
-            exchange="binance", trading_pair="BTC-USDT"
-        )
+
+        adapter = CandlesBaseAdapter(exchange="binance", trading_pair="BTC-USDT")
         adapter._feed.add_candle(_make_candle(500))
 
         adapter.reset_with_dataframe(pd.DataFrame())

--- a/tests/unit/hb_compat/test_data_types.py
+++ b/tests/unit/hb_compat/test_data_types.py
@@ -9,18 +9,21 @@ class TestCandlesConfig:
 
     def test_required_fields(self):
         from candles_feed.hb_compat.data_types import CandlesConfig
+
         config = CandlesConfig(connector="binance", trading_pair="BTC-USDT")
         assert config.connector == "binance"
         assert config.trading_pair == "BTC-USDT"
 
     def test_defaults(self):
         from candles_feed.hb_compat.data_types import CandlesConfig
+
         config = CandlesConfig(connector="binance", trading_pair="BTC-USDT")
         assert config.interval == "1m"
         assert config.max_records == 500
 
     def test_custom_values(self):
         from candles_feed.hb_compat.data_types import CandlesConfig
+
         config = CandlesConfig(
             connector="okx", trading_pair="ETH-USDT", interval="5m", max_records=1000
         )
@@ -30,6 +33,7 @@ class TestCandlesConfig:
 
     def test_missing_required_raises(self):
         from candles_feed.hb_compat.data_types import CandlesConfig
+
         with pytest.raises(ValidationError):
             CandlesConfig(connector="binance")  # missing trading_pair
 
@@ -39,6 +43,7 @@ class TestHistoricalCandlesConfig:
 
     def test_all_fields(self):
         from candles_feed.hb_compat.data_types import HistoricalCandlesConfig
+
         config = HistoricalCandlesConfig(
             connector_name="binance",
             trading_pair="BTC-USDT",
@@ -54,6 +59,7 @@ class TestHistoricalCandlesConfig:
 
     def test_all_fields_required(self):
         from candles_feed.hb_compat.data_types import HistoricalCandlesConfig
+
         with pytest.raises(ValidationError):
             HistoricalCandlesConfig(connector_name="binance", trading_pair="BTC-USDT")
 
@@ -63,11 +69,13 @@ class TestUnsupportedConnectorError:
 
     def test_message_includes_connector(self):
         from candles_feed.hb_compat.data_types import UnsupportedConnectorError
+
         exc = UnsupportedConnectorError("dydx")
         assert "dydx" in str(exc)
 
     def test_is_exception(self):
         from candles_feed.hb_compat.data_types import UnsupportedConnectorError
+
         assert issubclass(UnsupportedConnectorError, Exception)
 
 
@@ -83,6 +91,7 @@ class TestPublicAPI:
             HistoricalCandlesConfig,
             UnsupportedConnectorError,
         )
+
         assert CandlesBaseAdapter is not None
         assert CandlesBaseProtocol is not None
         assert CandlesConfig is not None

--- a/tests/unit/hb_compat/test_factory.py
+++ b/tests/unit/hb_compat/test_factory.py
@@ -14,6 +14,7 @@ class TestCandlesFactory:
         candle = CandlesFactory.get_candle(config)
 
         from candles_feed.hb_compat.adapter import CandlesBaseAdapter
+
         assert isinstance(candle, CandlesBaseAdapter)
 
     def test_get_candle_passes_config_fields(self):

--- a/tests/unit/hb_compat/test_protocols.py
+++ b/tests/unit/hb_compat/test_protocols.py
@@ -10,6 +10,7 @@ class TestCandlesBaseProtocol:
 
     def test_protocol_is_importable(self):
         from candles_feed.hb_compat.protocols import CandlesBaseProtocol
+
         assert CandlesBaseProtocol is not None
 
     def test_protocol_is_runtime_checkable(self):
@@ -18,15 +19,25 @@ class TestCandlesBaseProtocol:
         class FakeCandles:
             # Python 3.12+ requires @property for Protocol property members
             @property
-            def name(self) -> str: return "test"
+            def name(self) -> str:
+                return "test"
+
             @property
-            def interval(self) -> str: return "1m"
+            def interval(self) -> str:
+                return "1m"
+
             @property
-            def max_records(self) -> int: return 500
+            def max_records(self) -> int:
+                return 500
+
             @property
-            def ready(self) -> bool: return True
+            def ready(self) -> bool:
+                return True
+
             @property
-            def interval_in_seconds(self) -> int: return 60
+            def interval_in_seconds(self) -> int:
+                return 60
+
             @property
             def candles_df(self) -> pd.DataFrame:
                 return pd.DataFrame()

--- a/tests/unit/integration/test_monitoring.py
+++ b/tests/unit/integration/test_monitoring.py
@@ -69,7 +69,6 @@ class TestPrometheusMetricsExporter:
         assert "candles_feed_test_metric_2 3.14" in metrics_text
         assert "candles_feed_test_metric_with_dashes 100" in metrics_text
 
-    @pytest.mark.asyncio
     async def test_metrics_handler(self, exporter, monitoring_manager):
         """Test metrics HTTP handler."""
         from aiohttp.test_utils import make_mocked_request
@@ -113,7 +112,6 @@ class TestHealthCheckServer:
         """Create health check server for testing."""
         return HealthCheckServer(monitoring_manager, integration_config)
 
-    @pytest.mark.asyncio
     async def test_health_handler(self, health_server, monitoring_manager):
         """Test health check handler."""
         from aiohttp.test_utils import make_mocked_request
@@ -139,7 +137,6 @@ class TestHealthCheckServer:
         assert response_data["error_count"] == 0
         assert "checks" in response_data
 
-    @pytest.mark.asyncio
     async def test_readiness_handler(self, health_server, monitoring_manager):
         """Test readiness check handler."""
         from aiohttp.test_utils import make_mocked_request
@@ -160,7 +157,6 @@ class TestHealthCheckServer:
         response_data = json.loads(response.text)
         assert response_data["ready"] is True
 
-    @pytest.mark.asyncio
     async def test_liveness_handler(self, health_server):
         """Test liveness check handler."""
         from aiohttp.test_utils import make_mocked_request

--- a/tests/unit/mocking_resources/conftest.py
+++ b/tests/unit/mocking_resources/conftest.py
@@ -70,11 +70,3 @@ async def binance_mock_server():
 
     # Clean up
     await server.stop()
-
-
-# @pytest.fixture
-# def event_loop():
-#     """Create an event loop for each test."""
-#     loop = asyncio.get_event_loop_policy().new_event_loop()
-#     yield loop
-#     loop.close()

--- a/tests/unit/mocking_resources/core/test_exchange_plugin.py
+++ b/tests/unit/mocking_resources/core/test_exchange_plugin.py
@@ -2,10 +2,10 @@
 Unit tests for the ExchangePlugin abstract base class in mocking_resources.
 """
 
-import unittest
 from typing import Any
 from unittest.mock import MagicMock
 
+import pytest
 from aiohttp import web
 
 from candles_feed.adapters.binance.spot_adapter import BinanceSpotAdapter
@@ -14,7 +14,7 @@ from candles_feed.mocking_resources.core.exchange_plugin import ExchangePlugin
 from candles_feed.mocking_resources.core.exchange_type import ExchangeType
 
 
-class TestExchangePlugin(unittest.TestCase):
+class TestExchangePlugin:
     """Tests for the ExchangePlugin abstract base class."""
 
     class ConcreteExchangePlugin(ExchangePlugin):
@@ -94,29 +94,30 @@ class TestExchangePlugin(unittest.TestCase):
                 "limit": params.get("limit", "100"),
             }
 
-    def setUp(self):
+    @pytest.fixture(autouse=True)
+    def setup(self):
         """Set up test fixtures."""
         self.exchange_type = ExchangeType.BINANCE_SPOT
         self.plugin = self.ConcreteExchangePlugin(self.exchange_type, BinanceSpotAdapter)
 
     def test_init(self):
         """Test initialization of the plugin."""
-        self.assertEqual(self.plugin.exchange_type, self.exchange_type)
+        assert self.plugin.exchange_type == self.exchange_type
 
     def test_rest_routes(self):
         """Test the rest_routes property."""
         routes = self.plugin.rest_routes
-        self.assertIsInstance(routes, dict)
-        self.assertEqual(len(routes), 2)
-        self.assertEqual(routes["/api/test"], ("GET", "handle_test"))
-        self.assertEqual(routes["/api/candles"], ("GET", "handle_klines"))
+        assert isinstance(routes, dict)
+        assert len(routes) == 2
+        assert routes["/api/test"] == ("GET", "handle_test")
+        assert routes["/api/candles"] == ("GET", "handle_klines")
 
     def test_ws_routes(self):
         """Test the ws_routes property."""
         routes = self.plugin.ws_routes
-        self.assertIsInstance(routes, dict)
-        self.assertEqual(len(routes), 1)
-        self.assertEqual(routes["/ws"], "handle_websocket")
+        assert isinstance(routes, dict)
+        assert len(routes) == 1
+        assert routes["/ws"] == "handle_websocket"
 
     def test_format_rest_candles(self):
         """Test formatting REST candles response."""
@@ -137,14 +138,14 @@ class TestExchangePlugin(unittest.TestCase):
 
         result = self.plugin.format_rest_candles(candles, "BTCUSDT", "1m")
 
-        self.assertIsInstance(result, list)
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result[0]["timestamp"], candles[0].timestamp)
-        self.assertEqual(result[0]["open"], candles[0].open)
-        self.assertEqual(result[0]["high"], candles[0].high)
-        self.assertEqual(result[0]["low"], candles[0].low)
-        self.assertEqual(result[0]["close"], candles[0].close)
-        self.assertEqual(result[0]["volume"], candles[0].volume)
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]["timestamp"] == candles[0].timestamp
+        assert result[0]["open"] == candles[0].open
+        assert result[0]["high"] == candles[0].high
+        assert result[0]["low"] == candles[0].low
+        assert result[0]["close"] == candles[0].close
+        assert result[0]["volume"] == candles[0].volume
 
     def test_format_ws_candle_message(self):
         """Test formatting WebSocket candle message."""
@@ -163,17 +164,17 @@ class TestExchangePlugin(unittest.TestCase):
 
         result = self.plugin.format_ws_candle_message(candle, "BTCUSDT", "1m", is_final=True)
 
-        self.assertIsInstance(result, dict)
-        self.assertEqual(result["type"], "candle")
-        self.assertEqual(result["data"]["timestamp"], candle.timestamp)
-        self.assertEqual(result["data"]["trading_pair"], "BTCUSDT")
-        self.assertEqual(result["data"]["interval"], "1m")
-        self.assertEqual(result["data"]["open"], candle.open)
-        self.assertEqual(result["data"]["high"], candle.high)
-        self.assertEqual(result["data"]["low"], candle.low)
-        self.assertEqual(result["data"]["close"], candle.close)
-        self.assertEqual(result["data"]["volume"], candle.volume)
-        self.assertEqual(result["data"]["final"], True)
+        assert isinstance(result, dict)
+        assert result["type"] == "candle"
+        assert result["data"]["timestamp"] == candle.timestamp
+        assert result["data"]["trading_pair"] == "BTCUSDT"
+        assert result["data"]["interval"] == "1m"
+        assert result["data"]["open"] == candle.open
+        assert result["data"]["high"] == candle.high
+        assert result["data"]["low"] == candle.low
+        assert result["data"]["close"] == candle.close
+        assert result["data"]["volume"] == candle.volume
+        assert result["data"]["final"] is True
 
     def test_parse_ws_subscription(self):
         """Test parsing WebSocket subscription message."""
@@ -186,9 +187,9 @@ class TestExchangePlugin(unittest.TestCase):
 
         result = self.plugin.parse_ws_subscription(message)
 
-        self.assertIsInstance(result, list)
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result[0], ("BTCUSDT", "1m"))
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0] == ("BTCUSDT", "1m")
 
     def test_create_ws_subscription_success(self):
         """Test creating WebSocket subscription success response."""
@@ -202,19 +203,19 @@ class TestExchangePlugin(unittest.TestCase):
 
         result = self.plugin.create_ws_subscription_success(message, subscriptions)
 
-        self.assertIsInstance(result, dict)
-        self.assertEqual(result["type"], "subscribed")
-        self.assertEqual(result["channel"], "candles")
-        self.assertEqual(len(result["subscriptions"]), 2)
-        self.assertEqual(result["subscriptions"][0]["trading_pair"], "BTCUSDT")
-        self.assertEqual(result["subscriptions"][0]["interval"], "1m")
-        self.assertEqual(result["subscriptions"][1]["trading_pair"], "ETHUSDT")
-        self.assertEqual(result["subscriptions"][1]["interval"], "5m")
+        assert isinstance(result, dict)
+        assert result["type"] == "subscribed"
+        assert result["channel"] == "candles"
+        assert len(result["subscriptions"]) == 2
+        assert result["subscriptions"][0]["trading_pair"] == "BTCUSDT"
+        assert result["subscriptions"][0]["interval"] == "1m"
+        assert result["subscriptions"][1]["trading_pair"] == "ETHUSDT"
+        assert result["subscriptions"][1]["interval"] == "5m"
 
     def test_create_ws_subscription_key(self):
         """Test creating WebSocket subscription key."""
         result = self.plugin.create_ws_subscription_key("BTCUSDT", "1m")
-        self.assertEqual(result, "BTCUSDT_1m")
+        assert result == "BTCUSDT_1m"
 
     def test_parse_rest_candles_params(self):
         """Test parsing REST candles parameters."""
@@ -230,18 +231,14 @@ class TestExchangePlugin(unittest.TestCase):
 
         result = self.plugin.parse_rest_candles_params(mock_request)
 
-        self.assertIsInstance(result, dict)
-        self.assertEqual(result["symbol"], "BTCUSDT")
-        self.assertEqual(result["interval"], "1m")
-        self.assertEqual(result["start_time"], "1613677200000")
-        self.assertEqual(result["end_time"], "1613680800000")
-        self.assertEqual(result["limit"], "500")
+        assert isinstance(result, dict)
+        assert result["symbol"] == "BTCUSDT"
+        assert result["interval"] == "1m"
+        assert result["start_time"] == "1613677200000"
+        assert result["end_time"] == "1613680800000"
+        assert result["limit"] == "500"
 
     def test_normalize_trading_pair(self):
         """Test normalizing trading pair."""
         result = self.plugin.normalize_trading_pair("btcusdt")
-        self.assertEqual(result, "BTCUSDT")
-
-
-if __name__ == "__main__":
-    unittest.main()
+        assert result == "BTCUSDT"

--- a/tests/unit/mocking_resources/core/test_exchange_type.py
+++ b/tests/unit/mocking_resources/core/test_exchange_type.py
@@ -2,53 +2,47 @@
 Unit tests for the ExchangeType enum in mocking_resources.
 """
 
-import unittest
-
 from candles_feed.mocking_resources.core.exchange_type import ExchangeType
 
 
-class TestExchangeType(unittest.TestCase):
+class TestExchangeType:
     """Tests for the ExchangeType enum."""
 
     def test_enum_values(self):
         """Test that the enum has the expected values."""
         # Spot exchanges
-        self.assertEqual(ExchangeType.BINANCE_SPOT.value, "binance_spot")
-        self.assertEqual(ExchangeType.BYBIT_SPOT.value, "bybit_spot")
-        self.assertEqual(ExchangeType.COINBASE_ADVANCED_TRADE.value, "coinbase_advanced_trade")
-        self.assertEqual(ExchangeType.KRAKEN_SPOT.value, "kraken_spot")
-        self.assertEqual(ExchangeType.KUCOIN_SPOT.value, "kucoin_spot")
-        self.assertEqual(ExchangeType.OKX_SPOT.value, "okx_spot")
-        self.assertEqual(ExchangeType.GATE_IO_SPOT.value, "gate_io_spot")
-        self.assertEqual(ExchangeType.MEXC_SPOT.value, "mexc_spot")
-        self.assertEqual(ExchangeType.HYPERLIQUID_SPOT.value, "hyperliquid_spot")
-        self.assertEqual(ExchangeType.ASCEND_EX_SPOT.value, "ascend_ex_spot")
+        assert ExchangeType.BINANCE_SPOT.value == "binance_spot"
+        assert ExchangeType.BYBIT_SPOT.value == "bybit_spot"
+        assert ExchangeType.COINBASE_ADVANCED_TRADE.value == "coinbase_advanced_trade"
+        assert ExchangeType.KRAKEN_SPOT.value == "kraken_spot"
+        assert ExchangeType.KUCOIN_SPOT.value == "kucoin_spot"
+        assert ExchangeType.OKX_SPOT.value == "okx_spot"
+        assert ExchangeType.GATE_IO_SPOT.value == "gate_io_spot"
+        assert ExchangeType.MEXC_SPOT.value == "mexc_spot"
+        assert ExchangeType.HYPERLIQUID_SPOT.value == "hyperliquid_spot"
+        assert ExchangeType.ASCEND_EX_SPOT.value == "ascend_ex_spot"
 
         # Perpetual exchanges
-        self.assertEqual(ExchangeType.BINANCE_PERPETUAL.value, "binance_perpetual")
-        self.assertEqual(ExchangeType.BYBIT_PERPETUAL.value, "bybit_perpetual")
-        self.assertEqual(ExchangeType.KUCOIN_PERPETUAL.value, "kucoin_perpetual")
-        self.assertEqual(ExchangeType.OKX_PERPETUAL.value, "okx_perpetual")
-        self.assertEqual(ExchangeType.GATE_IO_PERPETUAL.value, "gate_io_perpetual")
-        self.assertEqual(ExchangeType.MEXC_PERPETUAL.value, "mexc_perpetual")
-        self.assertEqual(ExchangeType.HYPERLIQUID_PERPETUAL.value, "hyperliquid_perpetual")
+        assert ExchangeType.BINANCE_PERPETUAL.value == "binance_perpetual"
+        assert ExchangeType.BYBIT_PERPETUAL.value == "bybit_perpetual"
+        assert ExchangeType.KUCOIN_PERPETUAL.value == "kucoin_perpetual"
+        assert ExchangeType.OKX_PERPETUAL.value == "okx_perpetual"
+        assert ExchangeType.GATE_IO_PERPETUAL.value == "gate_io_perpetual"
+        assert ExchangeType.MEXC_PERPETUAL.value == "mexc_perpetual"
+        assert ExchangeType.HYPERLIQUID_PERPETUAL.value == "hyperliquid_perpetual"
 
     def test_access_by_name(self):
         """Test accessing enum values by name."""
-        self.assertEqual(ExchangeType.BINANCE_SPOT, ExchangeType["BINANCE_SPOT"])
-        self.assertEqual(ExchangeType.BYBIT_PERPETUAL, ExchangeType["BYBIT_PERPETUAL"])
+        assert ExchangeType["BINANCE_SPOT"] == ExchangeType.BINANCE_SPOT
+        assert ExchangeType["BYBIT_PERPETUAL"] == ExchangeType.BYBIT_PERPETUAL
 
     def test_iteration(self):
         """Test that we can iterate over the enum."""
         count = 0
         for exchange_type in ExchangeType:
-            self.assertIsInstance(exchange_type, ExchangeType)
+            assert isinstance(exchange_type, ExchangeType)
             count += 1
 
         # Make sure we have the expected number of exchange types
         # Update this if more exchanges are added
-        self.assertEqual(count, 18)
-
-
-if __name__ == "__main__":
-    unittest.main()
+        assert count == 18

--- a/tests/unit/mocking_resources/core/test_factory.py
+++ b/tests/unit/mocking_resources/core/test_factory.py
@@ -2,8 +2,9 @@
 Unit tests for the server factory in mocking_resources.
 """
 
-import unittest
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from candles_feed.mocking_resources.core import ExchangeType, create_mock_server
 from candles_feed.mocking_resources.core.factory import (
@@ -13,12 +14,12 @@ from candles_feed.mocking_resources.core.factory import (
 )
 
 
-class TestFactory(unittest.TestCase):
+class TestFactory:
     """Tests for the mock server factory functions."""
 
-    def setUp(self):
-        """Set up test fixtures."""
-        # Clear the plugin registry before each test
+    @pytest.fixture(autouse=True)
+    def clear_registry(self):
+        """Clear the plugin registry before each test."""
         _PLUGIN_REGISTRY.clear()
 
     def test_register_plugin(self):
@@ -28,8 +29,8 @@ class TestFactory(unittest.TestCase):
 
         register_plugin(exchange_type, mock_plugin)
 
-        self.assertIn(exchange_type, _PLUGIN_REGISTRY)
-        self.assertEqual(_PLUGIN_REGISTRY[exchange_type], mock_plugin)
+        assert exchange_type in _PLUGIN_REGISTRY
+        assert _PLUGIN_REGISTRY[exchange_type] == mock_plugin
 
     def test_register_plugin_duplicate(self):
         """Test that registering a duplicate plugin raises an error."""
@@ -38,7 +39,7 @@ class TestFactory(unittest.TestCase):
         register_plugin(exchange_type, mock_plugin)
 
         # Act/Assert
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             register_plugin(exchange_type, mock_plugin)
 
     def test_get_plugin_registered(self):
@@ -49,7 +50,7 @@ class TestFactory(unittest.TestCase):
 
         plugin = get_plugin(exchange_type)
 
-        self.assertEqual(plugin, mock_plugin)
+        assert plugin == mock_plugin
 
     def test_get_plugin_auto_import(self):
         """Test that get_plugin auto-imports plugins."""
@@ -66,10 +67,10 @@ class TestFactory(unittest.TestCase):
 
         plugin = get_plugin(exchange_type)
 
-        self.assertIsNotNone(plugin)
-        self.assertEqual(plugin, mock_plugin)
+        assert plugin is not None
+        assert plugin == mock_plugin
         # Verify the plugin was registered
-        self.assertIn(exchange_type, _PLUGIN_REGISTRY)
+        assert exchange_type in _PLUGIN_REGISTRY
 
     @patch("importlib.import_module")
     def test_get_plugin_import_error(self, mock_import):
@@ -79,8 +80,8 @@ class TestFactory(unittest.TestCase):
 
         plugin = get_plugin(exchange_type)
 
-        self.assertIsNone(plugin)
-        self.assertNotIn(exchange_type, _PLUGIN_REGISTRY)
+        assert plugin is None
+        assert exchange_type not in _PLUGIN_REGISTRY
 
     def test_create_mock_server(self):
         """Test creating a mock server directly."""
@@ -93,16 +94,16 @@ class TestFactory(unittest.TestCase):
             trading_pairs=[("BTCUSDT", "1m", 50000.0)],
         )
 
-        self.assertIsNotNone(server)
-        self.assertEqual(server.host, "test_host")
-        self.assertEqual(server.port, 1234)
-        self.assertEqual(server.exchange_type, ExchangeType.BINANCE_SPOT)
+        assert server is not None
+        assert server.host == "test_host"
+        assert server.port == 1234
+        assert server.exchange_type == ExchangeType.BINANCE_SPOT
 
         # Check that the trading pair is in the server's trading_pairs dictionary
         # The implementation uses the normalized trading pair as the key
         # This could be "BTC-USDT" or another format depending on the implementation
         # Just check that the 50000.0 price is in the values
-        self.assertIn(50000.0, server.trading_pairs.values())
+        assert 50000.0 in server.trading_pairs.values()
 
     def test_create_mock_server_no_plugin(self):
         """Test handling when no plugin is found."""
@@ -113,26 +114,22 @@ class TestFactory(unittest.TestCase):
 
         # We'll just verify that create_mock_server works
         server = create_mock_server(exchange_type=ExchangeType.BINANCE_SPOT)
-        self.assertIsNotNone(server)
+        assert server is not None
 
     def test_create_mock_server_default_trading_pairs(self):
         """Test creating a mock server with default trading pairs."""
         server = create_mock_server(exchange_type=ExchangeType.BINANCE_SPOT)
 
-        self.assertEqual(server.host, "127.0.0.1")
-        self.assertEqual(server.port, 8082)
+        assert server.host == "127.0.0.1"
+        assert server.port == 8082
 
         # Check that default trading pairs were added with expected prices
         # The implementation normalizes trading pairs, so we need to check values
         # rather than specific keys
         trading_pair_values = list(server.trading_pairs.values())
-        self.assertIn(50000.0, trading_pair_values)  # BTC price
-        self.assertIn(3000.0, trading_pair_values)  # ETH price
-        self.assertIn(100.0, trading_pair_values)  # SOL price
+        assert 50000.0 in trading_pair_values  # BTC price
+        assert 3000.0 in trading_pair_values  # ETH price
+        assert 100.0 in trading_pair_values  # SOL price
 
         # Also check that we have the expected number of trading pairs
-        self.assertEqual(len(server.trading_pairs), 3)
-
-
-if __name__ == "__main__":
-    unittest.main()
+        assert len(server.trading_pairs) == 3

--- a/tests/unit/mocking_resources/core/test_server.py
+++ b/tests/unit/mocking_resources/core/test_server.py
@@ -3,8 +3,6 @@ Unit tests for the MockedExchangeServer class in mocking_resources.
 """
 
 import asyncio
-import unittest
-from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -17,7 +15,7 @@ from candles_feed.mocking_resources.core.server import MockedExchangeServer
 from candles_feed.mocking_resources.exchange_server_plugins.mocked_plugin import MockedPlugin
 
 
-class TestMockExchangeServer(IsolatedAsyncioTestCase):
+class TestMockExchangeServer:
     """Tests for the MockedExchangeServer class."""
 
     class SamplePlugin(ExchangePlugin):
@@ -95,7 +93,8 @@ class TestMockExchangeServer(IsolatedAsyncioTestCase):
                 "limit": params.get("limit", "100"),
             }
 
-    def setUp(self):
+    @pytest.fixture(autouse=True)
+    def setup(self):
         """Set up test fixtures."""
         self.plugin = self.SamplePlugin(ExchangeType.BINANCE_SPOT, BinanceSpotAdapter)
         self.server = MockedExchangeServer(self.plugin, "127.0.0.1", 8082)
@@ -103,26 +102,26 @@ class TestMockExchangeServer(IsolatedAsyncioTestCase):
     @patch("candles_feed.mocking_resources.core.server.web.AppRunner")
     def test_init(self, mock_app_runner):
         """Test initialization of the server."""
-        self.assertEqual(self.server.plugin, self.plugin)
-        self.assertEqual(self.server.exchange_type, ExchangeType.BINANCE_SPOT)
-        self.assertEqual(self.server.host, "127.0.0.1")
-        self.assertEqual(self.server.port, 8082)
-        self.assertIsInstance(self.server.app, web.Application)
-        self.assertEqual(self.server.candles, {})
-        self.assertEqual(self.server.last_candle_time, {})
-        self.assertEqual(self.server.trading_pairs, {})
-        self.assertEqual(self.server.subscriptions, {})
+        assert self.server.plugin == self.plugin
+        assert self.server.exchange_type == ExchangeType.BINANCE_SPOT
+        assert self.server.host == "127.0.0.1"
+        assert self.server.port == 8082
+        assert isinstance(self.server.app, web.Application)
+        assert self.server.candles == {}
+        assert self.server.last_candle_time == {}
+        assert self.server.trading_pairs == {}
+        assert self.server.subscriptions == {}
 
     def test_routes_initialization(self):
         """Test that the app is initialized properly."""
         # Just test that the app is a valid aiohttp Application
-        self.assertIsInstance(self.server.app, web.Application)
+        assert isinstance(self.server.app, web.Application)
 
         # Replace the route checking with mock verification
         # since our test plugin doesn't actually define working handlers
         plugin = MockedPlugin(ExchangeType.MOCK)
-        self.assertIsNotNone(plugin.rest_routes)
-        self.assertIsNotNone(plugin.ws_routes)
+        assert plugin.rest_routes is not None
+        assert plugin.ws_routes is not None
 
     def test_add_trading_pair(self):
         """Test adding a trading pair."""
@@ -139,12 +138,12 @@ class TestMockExchangeServer(IsolatedAsyncioTestCase):
             self.server.add_trading_pair(trading_pair, interval, initial_price)
 
             # Verify trading pair was added to the right collections
-            self.assertIn(trading_pair, self.server.trading_pairs)
-            self.assertEqual(self.server.trading_pairs[trading_pair], initial_price)
+            assert trading_pair in self.server.trading_pairs
+            assert self.server.trading_pairs[trading_pair] == initial_price
 
             # Verify dictionaries were initialized
-            self.assertIn(trading_pair, self.server.candles)
-            self.assertIn(trading_pair, self.server.last_candle_time)
+            assert trading_pair in self.server.candles
+            assert trading_pair in self.server.last_candle_time
 
             # Verify correct method was called to generate candles
             mock_generate.assert_called_once_with(trading_pair, interval, initial_price)
@@ -153,9 +152,9 @@ class TestMockExchangeServer(IsolatedAsyncioTestCase):
         """Test setting network conditions."""
         self.server.set_network_conditions(latency_ms=50, packet_loss_rate=0.1, error_rate=0.05)
 
-        self.assertEqual(self.server.latency_ms, 50)
-        self.assertEqual(self.server.packet_loss_rate, 0.1)
-        self.assertEqual(self.server.error_rate, 0.05)
+        assert self.server.latency_ms == 50
+        assert self.server.packet_loss_rate == 0.1
+        assert self.server.error_rate == 0.05
 
     def test_update_rate_limits(self):
         """Test updating rate limits directly."""
@@ -172,12 +171,11 @@ class TestMockExchangeServer(IsolatedAsyncioTestCase):
         self.server.rate_limits["ws"]["burst"] = 20
 
         # Check that values were updated
-        self.assertEqual(self.server.rate_limits["rest"]["limit"], 500)
-        self.assertEqual(self.server.rate_limits["rest"]["period_ms"], 30000)
-        self.assertEqual(self.server.rate_limits["ws"]["limit"], 10)
-        self.assertEqual(self.server.rate_limits["ws"]["burst"], 20)
+        assert self.server.rate_limits["rest"]["limit"] == 500
+        assert self.server.rate_limits["rest"]["period_ms"] == 30000
+        assert self.server.rate_limits["ws"]["limit"] == 10
+        assert self.server.rate_limits["ws"]["burst"] == 20
 
-    @pytest.mark.asyncio
     @patch("candles_feed.mocking_resources.core.server.web.AppRunner")
     @patch("candles_feed.mocking_resources.core.server.web.TCPSite")
     async def test_start(self, mock_tcp_site, mock_app_runner):
@@ -196,10 +194,9 @@ class TestMockExchangeServer(IsolatedAsyncioTestCase):
         mock_tcp_site.assert_called_once_with(mock_runner, "127.0.0.1", 8082)
         mock_site.start.assert_called_once()
 
-        self.assertEqual(url, "http://127.0.0.1:8082")
-        self.assertEqual(len(self.server._tasks), 1)
+        assert url == "http://127.0.0.1:8082"
+        assert len(self.server._tasks) == 1
 
-    @pytest.mark.asyncio
     async def test_stop(self):
         """Test stopping the server."""
         self.server.runner = AsyncMock()
@@ -223,7 +220,7 @@ class TestMockExchangeServer(IsolatedAsyncioTestCase):
         await self.server.stop()
 
         # Verify the task was cancelled
-        self.assertTrue(task.cancelled())
+        assert task.cancelled()
 
         # Check WebSocket connection is closed
         mock_ws.close.assert_called_once()
@@ -233,9 +230,9 @@ class TestMockExchangeServer(IsolatedAsyncioTestCase):
         self.server.runner.cleanup.assert_called_once()
 
         # Connection state should be cleared
-        self.assertEqual(self.server._tasks, [])
-        self.assertEqual(self.server.ws_connections, set())
-        self.assertEqual(self.server.subscriptions, {})
+        assert self.server._tasks == []
+        assert self.server.ws_connections == set()
+        assert self.server.subscriptions == {}
 
     @patch("time.time")
     def test_interval_to_seconds(self, mock_time):
@@ -244,14 +241,12 @@ class TestMockExchangeServer(IsolatedAsyncioTestCase):
         plugin = MockedPlugin(ExchangeType.MOCK)
         self.server.plugin = plugin
 
-        self.assertEqual(self.server.plugin._interval_to_seconds("1s"), 1)
-        self.assertEqual(self.server.plugin._interval_to_seconds("1m"), 60)
-        self.assertEqual(self.server.plugin._interval_to_seconds("5m"), 300)
-        self.assertEqual(self.server.plugin._interval_to_seconds("1h"), 3600)
-        self.assertEqual(self.server.plugin._interval_to_seconds("1d"), 86400)
-        self.assertEqual(self.server.plugin._interval_to_seconds("1w"), 604800)
-
-        # Default case - no need to test invalid intervals since that's delegated
+        assert self.server.plugin._interval_to_seconds("1s") == 1
+        assert self.server.plugin._interval_to_seconds("1m") == 60
+        assert self.server.plugin._interval_to_seconds("5m") == 300
+        assert self.server.plugin._interval_to_seconds("1h") == 3600
+        assert self.server.plugin._interval_to_seconds("1d") == 86400
+        assert self.server.plugin._interval_to_seconds("1w") == 604800
 
     def test_check_rate_limit(self):
         """Test rate limit checking."""
@@ -271,27 +266,24 @@ class TestMockExchangeServer(IsolatedAsyncioTestCase):
         # Test REST API rate limiting - make sure we're below the limit
         for _ in range(10):
             result = self.server._check_rate_limit(ip, "rest")
-            self.assertTrue(result)
+            assert result
 
         # Verify request counts were tracked
-        self.assertIn(ip, self.server.request_counts["rest"])
-        self.assertEqual(len(self.server.request_counts["rest"][ip]["timestamps"]), 10)
+        assert ip in self.server.request_counts["rest"]
+        assert len(self.server.request_counts["rest"][ip]["timestamps"]) == 10
 
         # Test WebSocket API rate limiting - below the burst limit
         if "ws" in self.server.rate_limits and "burst" in self.server.rate_limits["ws"]:
             burst_limit = self.server.rate_limits["ws"]["burst"]
             for _ in range(burst_limit - 1):
                 result = self.server._check_rate_limit(ip, "ws")
-                self.assertTrue(result)
+                assert result
 
             # Verify request counts
-            self.assertIn(ip, self.server.request_counts["ws"])
+            assert ip in self.server.request_counts["ws"]
             if "timestamps" in self.server.request_counts["ws"][ip]:
-                self.assertEqual(
-                    len(self.server.request_counts["ws"][ip]["timestamps"]), burst_limit - 1
-                )
+                assert len(self.server.request_counts["ws"][ip]["timestamps"]) == burst_limit - 1
 
-    @pytest.mark.asyncio
     @patch("candles_feed.mocking_resources.core.server.asyncio.sleep")
     async def test_simulate_network_conditions_latency(self, mock_sleep):
         """Test simulating network latency."""
@@ -302,10 +294,7 @@ class TestMockExchangeServer(IsolatedAsyncioTestCase):
         await self.server._simulate_network_conditions()
 
         mock_sleep.assert_called_once_with(0.05)  # 50ms = 0.05s
-        # Return None to fix deprecation warning
-        return None
 
-    @pytest.mark.asyncio
     @patch("candles_feed.mocking_resources.core.server.random.random")
     @patch("candles_feed.mocking_resources.core.server.asyncio.sleep")
     async def test_simulate_network_conditions_packet_loss(self, mock_sleep, mock_random):
@@ -318,13 +307,9 @@ class TestMockExchangeServer(IsolatedAsyncioTestCase):
         mock_random.return_value = 0.4
 
         # Act & Assert
-        with self.assertRaises(web.HTTPRequestTimeout):
+        with pytest.raises(web.HTTPRequestTimeout):
             await self.server._simulate_network_conditions()
 
-        # Return None to fix deprecation warning
-        return None
-
-    @pytest.mark.asyncio
     @patch("candles_feed.mocking_resources.core.server.random.random")
     @patch("candles_feed.mocking_resources.core.server.random.choice")
     @patch("candles_feed.mocking_resources.core.server.asyncio.sleep")
@@ -341,12 +326,5 @@ class TestMockExchangeServer(IsolatedAsyncioTestCase):
         mock_choice.return_value = 500
 
         # Act & Assert
-        with self.assertRaises(web.HTTPInternalServerError):
+        with pytest.raises(web.HTTPInternalServerError):
             await self.server._simulate_network_conditions()
-
-        # Return None to fix deprecation warning
-        return None
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/unit/mocking_resources/exchange_server_plugins/ascend_ex/test_ascend_ex_spot_plugin.py
+++ b/tests/unit/mocking_resources/exchange_server_plugins/ascend_ex/test_ascend_ex_spot_plugin.py
@@ -158,7 +158,6 @@ class TestAscendExSpotPlugin:
         # Check key format
         assert key == "bar:1:BTC/USDT"
 
-    @pytest.mark.asyncio
     async def test_handle_instruments(self):
         """Test handling instruments endpoint."""
         from unittest.mock import AsyncMock, MagicMock

--- a/tests/unit/mocking_resources/exchange_server_plugins/binance/test_binance_perpetual_plugin.py
+++ b/tests/unit/mocking_resources/exchange_server_plugins/binance/test_binance_perpetual_plugin.py
@@ -179,7 +179,6 @@ class TestBinancePerpetualPlugin:
         # Check key format
         assert key == "btcusdt@kline_1m"
 
-    @pytest.mark.asyncio
     async def test_handle_instruments(self):
         """Test handling instruments endpoint."""
         from unittest.mock import AsyncMock, MagicMock

--- a/tests/unit/mocking_resources/exchange_server_plugins/binance/test_binance_spot_plugin.py
+++ b/tests/unit/mocking_resources/exchange_server_plugins/binance/test_binance_spot_plugin.py
@@ -179,7 +179,6 @@ class TestBinanceSpotPlugin:
         # Check key format
         assert key == "btcusdt@kline_1m"
 
-    @pytest.mark.asyncio
     async def test_handle_instruments(self):
         """Test handling instruments endpoint."""
         from unittest.mock import AsyncMock, MagicMock

--- a/tests/unit/mocking_resources/exchange_server_plugins/bybit/test_bybit_perpetual_plugin.py
+++ b/tests/unit/mocking_resources/exchange_server_plugins/bybit/test_bybit_perpetual_plugin.py
@@ -36,7 +36,6 @@ class TestBybitPerpetualPlugin:
         assert "/v5/market/time" in routes
         assert "/v5/market/instruments-info" in routes
 
-    @pytest.mark.asyncio
     async def test_parse_rest_candles_params(self):
         """Test parsing REST API parameters."""
         # Create a mock request with query parameters

--- a/tests/unit/mocking_resources/exchange_server_plugins/bybit/test_bybit_spot_plugin.py
+++ b/tests/unit/mocking_resources/exchange_server_plugins/bybit/test_bybit_spot_plugin.py
@@ -34,7 +34,6 @@ class TestBybitSpotPlugin:
         assert "/v5/market/time" in routes
         assert "/v5/market/instruments-info" in routes
 
-    @pytest.mark.asyncio
     async def test_parse_rest_candles_params(self):
         """Test parsing REST API parameters."""
         # Create a mock request with query parameters

--- a/tests/unit/mocking_resources/exchange_server_plugins/coinbase_advanced_trade/test_coinbase_advanced_trade_spot_plugin.py
+++ b/tests/unit/mocking_resources/exchange_server_plugins/coinbase_advanced_trade/test_coinbase_advanced_trade_spot_plugin.py
@@ -185,7 +185,6 @@ class TestCoinbaseAdvancedTradeSpotPlugin:
         # Check key format
         assert key == "candles_BTC-USD_60"
 
-    @pytest.mark.asyncio
     async def test_handle_products(self):
         """Test handling products endpoint."""
         from unittest.mock import AsyncMock, MagicMock
@@ -210,7 +209,6 @@ class TestCoinbaseAdvancedTradeSpotPlugin:
         # Response should not be None
         assert response is not None
 
-    @pytest.mark.asyncio
     async def test_handle_time(self):
         """Test handling time endpoint."""
         from unittest.mock import AsyncMock, MagicMock

--- a/tests/unit/mocking_resources/exchange_server_plugins/gate_io/test_gate_io_perpetual_plugin.py
+++ b/tests/unit/mocking_resources/exchange_server_plugins/gate_io/test_gate_io_perpetual_plugin.py
@@ -34,7 +34,6 @@ class TestGateIoPerpetualPlugin:
         assert routes["/api/v4/futures/usdt/candlesticks"][0] == "GET"
         assert routes["/api/v4/futures/usdt/candlesticks"][1] == "handle_klines"
 
-    @pytest.mark.asyncio
     async def test_parse_rest_candles_params(self):
         """Test parsing REST API parameters."""
         # Create a mock request with query parameters

--- a/tests/unit/mocking_resources/exchange_server_plugins/gate_io/test_gate_io_spot_plugin.py
+++ b/tests/unit/mocking_resources/exchange_server_plugins/gate_io/test_gate_io_spot_plugin.py
@@ -34,7 +34,6 @@ class TestGateIoSpotPlugin:
         assert routes["/api/v4/spot/candlesticks"][0] == "GET"
         assert routes["/api/v4/spot/candlesticks"][1] == "handle_klines"
 
-    @pytest.mark.asyncio
     async def test_parse_rest_candles_params(self):
         """Test parsing REST API parameters."""
         # Create a mock request with query parameters

--- a/tests/unit/mocking_resources/exchange_server_plugins/hyperliquid/test_hyperliquid_perpetual_plugin.py
+++ b/tests/unit/mocking_resources/exchange_server_plugins/hyperliquid/test_hyperliquid_perpetual_plugin.py
@@ -34,7 +34,6 @@ class TestHyperliquidPerpetualPlugin:
         assert routes["/info"][0] == "POST"
         assert routes["/info"][1] == "handle_klines"
 
-    @pytest.mark.asyncio
     async def test_parse_rest_candles_params(self):
         """Test parsing REST API parameters."""
         # Create a mock request with JSON body

--- a/tests/unit/mocking_resources/exchange_server_plugins/kraken/test_kraken_spot_plugin.py
+++ b/tests/unit/mocking_resources/exchange_server_plugins/kraken/test_kraken_spot_plugin.py
@@ -40,7 +40,6 @@ class TestKrakenSpotPlugin:
         assert routes[SPOT_CANDLES_ENDPOINT][1] == "handle_klines"
         assert TIME_ENDPOINT in routes
 
-    @pytest.mark.asyncio
     async def test_parse_rest_candles_params(self):
         """Test parsing REST API parameters."""
         # Create a mock request with query parameters

--- a/tests/unit/mocking_resources/exchange_server_plugins/kucoin/test_kucoin_spot_plugin.py
+++ b/tests/unit/mocking_resources/exchange_server_plugins/kucoin/test_kucoin_spot_plugin.py
@@ -34,7 +34,6 @@ class TestKucoinSpotPlugin:
         assert routes["/api/v1/market/candles"][0] == "GET"
         assert routes["/api/v1/market/candles"][1] == "handle_klines"
 
-    @pytest.mark.asyncio
     async def test_parse_rest_candles_params(self):
         """Test parsing REST API parameters."""
         # Create a mock request with query parameters

--- a/tests/unit/mocking_resources/exchange_server_plugins/mexc/test_mexc_spot_plugin.py
+++ b/tests/unit/mocking_resources/exchange_server_plugins/mexc/test_mexc_spot_plugin.py
@@ -32,7 +32,6 @@ class TestMEXCSpotPlugin:
         assert routes["/api/v3/klines"][0] == "GET"
         assert routes["/api/v3/klines"][1] == "handle_klines"
 
-    @pytest.mark.asyncio
     async def test_parse_rest_candles_params(self):
         """Test parsing REST API parameters."""
         # Create a mock request with query parameters

--- a/tests/unit/mocking_resources/exchange_server_plugins/okx/test_okx_perpetual_plugin.py
+++ b/tests/unit/mocking_resources/exchange_server_plugins/okx/test_okx_perpetual_plugin.py
@@ -40,7 +40,6 @@ class TestOKXPerpetualPlugin:
         assert "/api/v5/public/time" in routes
         assert "/api/v5/public/instruments" in routes
 
-    @pytest.mark.asyncio
     async def test_parse_rest_candles_params(self):
         """Test parsing REST API parameters."""
         # Create a mock request with query parameters

--- a/tests/unit/mocking_resources/exchange_server_plugins/okx/test_okx_spot_plugin.py
+++ b/tests/unit/mocking_resources/exchange_server_plugins/okx/test_okx_spot_plugin.py
@@ -36,7 +36,6 @@ class TestOKXSpotPlugin:
         assert "/api/v5/public/time" in routes
         assert "/api/v5/public/instruments" in routes
 
-    @pytest.mark.asyncio
     async def test_parse_rest_candles_params(self):
         """Test parsing REST API parameters."""
         # Create a mock request with query parameters

--- a/tests/unit/mocking_resources/exchange_server_plugins/test_mocked_plugin.py
+++ b/tests/unit/mocking_resources/exchange_server_plugins/test_mocked_plugin.py
@@ -34,7 +34,6 @@ class TestMockedPlugin:
         assert "/api/time" in routes
         assert "/api/instruments" in routes
 
-    @pytest.mark.asyncio
     async def test_parse_rest_candles_params(self):
         """Test parsing REST API parameters."""
         # Create a mock request with query parameters

--- a/tests/unit/mocking_resources/test_mock_plugin_integration.py
+++ b/tests/unit/mocking_resources/test_mock_plugin_integration.py
@@ -16,7 +16,6 @@ from candles_feed.mocking_resources.core.server import MockedExchangeServer
 class TestMockPluginIntegration:
     """Test the MockedPlugin integration with MockedExchangeServer."""
 
-    @pytest.mark.asyncio
     async def test_server_start(self, unused_tcp_port):
         """Test starting the server with the mock plugin."""
         # Get the mock plugin
@@ -43,7 +42,6 @@ class TestMockPluginIntegration:
         # Clean up
         await server.stop()
 
-    @pytest.mark.asyncio
     async def test_rest_candles_endpoint(self, mocked_server_fixture):
         """Test the REST API candles endpoint."""
         url = mocked_server_fixture.mocked_exchange_url
@@ -79,7 +77,6 @@ class TestMockPluginIntegration:
             assert "close" in candle
             assert "volume" in candle
 
-    @pytest.mark.asyncio
     async def test_websocket_connection(self, mocked_server_fixture):
         """Test WebSocket connection and subscription."""
         url = mocked_server_fixture.mocked_exchange_url

--- a/tests/unit/mocking_resources/test_server_with_simple_plugin.py
+++ b/tests/unit/mocking_resources/test_server_with_simple_plugin.py
@@ -14,7 +14,6 @@ from candles_feed.mocking_resources.exchange_server_plugins.mocked_plugin import
 class TestServerWithSimplePlugin:
     """Test the MockedExchangeServer with MockedPlugin."""
 
-    @pytest.mark.asyncio
     async def test_server_initialization(self, unused_tcp_port):
         """Test server initialization with MockedPlugin."""
         # Create server with MockedPlugin
@@ -34,7 +33,6 @@ class TestServerWithSimplePlugin:
         # Clean up
         await server.stop()
 
-    @pytest.mark.asyncio
     async def test_rest_candles_endpoint(self, unused_tcp_port):
         """Test the REST candles endpoint."""
         # Create server with MockedPlugin
@@ -86,7 +84,6 @@ class TestServerWithSimplePlugin:
         # Clean up
         await server.stop()
 
-    @pytest.mark.asyncio
     async def test_websocket_connection(self, unused_tcp_port):
         """Test WebSocket connection and subscription."""
         # Create server with MockedPlugin
@@ -142,7 +139,6 @@ class TestServerWithSimplePlugin:
         # Clean up
         await server.stop()
 
-    @pytest.mark.asyncio
     async def test_multiple_trading_pairs(self, unused_tcp_port):
         """Test handling multiple trading pairs."""
         # Create server with MockedPlugin
@@ -189,7 +185,6 @@ class TestServerWithSimplePlugin:
         # Clean up
         await server.stop()
 
-    @pytest.mark.asyncio
     async def test_time_endpoint(self, unused_tcp_port):
         """Test the time endpoint."""
         # Create server with MockedPlugin
@@ -221,7 +216,6 @@ class TestServerWithSimplePlugin:
         # Clean up
         await server.stop()
 
-    @pytest.mark.asyncio
     async def test_instruments_endpoint(self, unused_tcp_port):
         """Test the instruments endpoint."""
         # Create server with MockedPlugin

--- a/tests/unit/mocking_resources/test_simple_mock_plugin.py
+++ b/tests/unit/mocking_resources/test_simple_mock_plugin.py
@@ -49,7 +49,6 @@ class TestMockedPlugin:
         # Default for unknown interval
         assert self.plugin.get_interval_seconds("unknown") == 60
 
-    @pytest.mark.asyncio
     async def test_handle_klines(self):
         """Test handling klines (candles) REST API requests."""
         mock_server = Mock()
@@ -142,7 +141,6 @@ class TestMockedPlugin:
         timestamps = [int(candle["timestamp"]) for candle in response_2_json["data"]]
         assert timestamps == sorted(timestamps)
 
-    @pytest.mark.asyncio
     @patch(
         "candles_feed.mocking_resources.exchange_server_plugins.mocked_plugin.web.WebSocketResponse"
     )

--- a/tests/unit/mocking_resources/test_simple_mock_plugin.py.bak
+++ b/tests/unit/mocking_resources/test_simple_mock_plugin.py.bak
@@ -48,7 +48,6 @@ class TestMockedPlugin:
         # Default for unknown interval
         assert self.plugin.get_interval_seconds("unknown") == 60
 
-    @pytest.mark.asyncio
     async def test_handle_rest_candles_request(self):
         """Test handling REST API candles requests."""
         # Test with minimal parameters
@@ -86,7 +85,6 @@ class TestMockedPlugin:
         timestamps = [int(candle["timestamp"]) for candle in response["data"]]
         assert timestamps == sorted(timestamps)
 
-    @pytest.mark.asyncio
     async def test_handle_ws_connection(self):
         """Test handling WebSocket connections."""
         # Create mock websocket

--- a/tests/unit/test_hummingbot_integration.py
+++ b/tests/unit/test_hummingbot_integration.py
@@ -130,7 +130,6 @@ def mock_hummingbot_components(binance_rest_candles_response):
     return create_mock_hummingbot_components(rest_responses=rest_responses, ws_messages=ws_messages)
 
 
-@pytest.mark.asyncio
 async def test_create_candles_feed_with_hummingbot(mock_hummingbot_components):
     """Test creating a CandlesFeed with Hummingbot components.
 
@@ -179,7 +178,6 @@ async def test_create_candles_feed_with_hummingbot(mock_hummingbot_components):
         )
 
 
-@pytest.mark.asyncio
 async def test_candles_feed_rest_with_hummingbot(mock_hummingbot_components):
     """Test fetching candles with Hummingbot REST integration.
 
@@ -239,7 +237,6 @@ async def test_candles_feed_rest_with_hummingbot(mock_hummingbot_components):
             assert candles[0].close == 35050.3
 
 
-@pytest.mark.asyncio
 async def test_candles_feed_ws_with_hummingbot(mock_hummingbot_components):
     """Test WebSocket connection with Hummingbot integration.
 


### PR DESCRIPTION
## Summary

- Remove 211 redundant `@pytest.mark.asyncio` decorators across 66 files (asyncio_mode=auto makes them unnecessary)
- Migrate 4 `unittest.TestCase` files to plain pytest classes with `@pytest.fixture(autouse=True)` and plain `assert` statements
- Remove `IsolatedAsyncioTestCase` from `test_server.py` — async test methods work natively with asyncio_mode=auto
- Remove dead commented-out `event_loop` fixture from `tests/unit/mocking_resources/conftest.py`
- Add `pytest-xdist>=3.0.0` to dev dependencies (enables parallel test execution with `-n auto`)
- Apply ruff format to files touched during the refactor

## Files migrated from unittest.TestCase to plain pytest

- `tests/unit/mocking_resources/core/test_exchange_type.py`
- `tests/unit/mocking_resources/core/test_factory.py`
- `tests/unit/mocking_resources/core/test_exchange_plugin.py`
- `tests/unit/mocking_resources/core/test_server.py`

## Test results

1017 passed, 25 skipped across the full unit test suite (pre-existing collection error in `tests/unit/monitoring/test_prometheus_exporter.py` is unrelated to this PR).

## Test plan

- [ ] Run `pytest tests/unit` and verify 1017+ tests pass
- [ ] Confirm no `@pytest.mark.asyncio` decorators remain in test files
- [ ] Verify the 4 migrated files use plain `assert` and `@pytest.fixture`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Modernize the test suite to native pytest idioms, removing redundant asyncio markers and unittest.TestCase usage, while enabling parallel test execution and applying consistent formatting across touched files.

Enhancements:
- Migrate multiple unittest.TestCase-based tests to plain pytest classes with autouse fixtures and bare asserts.
- Remove now-unnecessary @pytest.mark.asyncio decorators across async tests relying on pytest asyncio_mode=auto.
- Apply ruff-based formatting cleanups to adapters, hb_compat modules, and tests for consistency.

Tests:
- Simplify async and mocking_resource tests to pure pytest style and remove dead event loop fixture.
- Ensure integration, performance, load, and e2e tests run without explicit asyncio markers.
- Add pytest-xdist as a development dependency to support parallel test execution.