### PR TITLE
fix(ci): replace permissions: read-all with deny-all default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions: read-all
+# Deny all permissions by default; each job requests only what it needs.
+permissions: {}
 
 jobs:
   ci:
@@ -36,13 +37,16 @@ jobs:
   branch-policy:
     name: "Branch Policy"
     runs-on: ubuntu-latest
+    permissions: {}
     if: github.event_name == 'pull_request' && github.base_ref == 'main'
     steps:
       - name: Check source branch
+        env:
+          HEAD_REF: ${{ github.head_ref }}
         run: |
-          if [ "${{ github.head_ref }}" != "development" ]; then
+          if [ "$HEAD_REF" != "development" ]; then
             echo "❌ PRs to main must come from development branch"
-            echo "   Source: ${{ github.head_ref }}"
+            echo "   Source: $HEAD_REF"
             echo "   Expected: development"
             exit 1
           fi
@@ -51,12 +55,15 @@ jobs:
   security-scanning:
     name: "Security Scanning"
     runs-on: ubuntu-latest
+    permissions: {}
     needs: [ci]
     if: always()
     steps:
       - name: Check security status
+        env:
+          CI_RESULT: ${{ needs.ci.result }}
         run: |
-          if [ "${{ needs.ci.result }}" != "success" ]; then
+          if [ "$CI_RESULT" != "success" ]; then
             echo "Security scanning failed"
             exit 1
           fi
@@ -65,12 +72,15 @@ jobs:
   ci-success:
     name: "CI Success"
     runs-on: ubuntu-latest
+    permissions: {}
     needs: [ci]
     if: always()
     steps:
       - name: Check CI status
+        env:
+          CI_RESULT: ${{ needs.ci.result }}
         run: |
-          if [ "${{ needs.ci.result }}" != "success" ]; then
+          if [ "$CI_RESULT" != "success" ]; then
             echo "CI failed"
             exit 1
           fi


### PR DESCRIPTION
Fixes CodeQL/ossf Scorecard SARIF upload failure on push events.

Permissions: read-all leaks security-events: read into the ci-framework reusable workflow GITHUB_TOKEN. ossf/scorecard-action detects the scope and attempts SARIF upload requiring security-events: write — fails with "Resource not accessible by integration" on push (masked on PRs).

Canonical fix (ci-framework v2.9.3/v2.9.4):
- permissions: read-all → permissions: {} at top level  
- Add permissions: {} to branch-policy, security-scanning, ci-success
- Env-var capture for github.head_ref / needs.ci.result (injection hardening)

Reference: hb-liquidations-feed PR #21 (commit 54873f0a) canonical fix

## Summary by Sourcery

Tighten GitHub Actions CI workflow permissions and harden branch and security checks to resolve SARIF upload issues and reduce token scope.

Bug Fixes:
- Resolve SARIF upload failures on push events caused by overly broad GITHUB_TOKEN permissions and missing security-events write scope.

Enhancements:
- Harden shell checks by passing github.head_ref and needs.ci.result via environment variables instead of interpolating expressions directly in shell conditions.

CI:
- Change the CI workflow to deny all permissions by default at the workflow level and require explicit permissions per job, adding empty permissions blocks for branch-policy, security-scanning, and ci-success jobs.