### PR TITLE
chore(ci): unify ci-framework reference to SHA pin

### DIFF
--- a/.github/workflows/cleanup-dev-files.yml
+++ b/.github/workflows/cleanup-dev-files.yml
@@ -30,7 +30,7 @@ on:
 jobs:
   cleanup:
     if: false
-    uses: Claire-s-Monster/ci-framework/.github/workflows/cleanup-dev-files.yml@v2.5.1
+    uses: Claire-s-Monster/ci-framework/.github/workflows/cleanup-dev-files.yml@1a9f71d1ebbd0b1393938a05434af724276934e1
     with:
       target_branches: >-
         ${{


### PR DESCRIPTION
## Summary
Unify all `Claire-s-Monster/ci-framework` references to the SHA pin used across all 13 sibling sub-packages.

## Files changed
- `.github/workflows/cleanup-dev-files.yml` — Updated legacy `@v2.5.1` to SHA pin `1a9f71d1ebbd0b1393938a05434af724276934e1`

## Context
Identified in the 2026-05-27 sub-package consistency audit. All 14 sub-packages reference the SHA `1a9f71d1ebbd0b1393938a05434af724276934e1`; this repo was the only one also carrying a legacy `@v2.5.1` reference.

## Test plan
- CI workflows are triggered on PR and must pass
- No functional code changes, only workflow reference updates

## Summary by Sourcery

CI:
- Update cleanup-dev-files GitHub Actions workflow to reference the ci-framework by SHA instead of a version tag.