### PR TITLE
fix(check): exclude live tests from default check task

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,10 @@ type-check = "mypy candles_feed"
 security = "bandit -c pyproject.toml -r candles_feed/"
 lint-cython = "cython-lint candles_feed"
 quality = { depends-on = ["lint", "type-check"] }
-check = { depends-on = ["format", "lint", "type-check", "test"] }
+# live tests excluded — they hit real exchange APIs and fail under geo-restrictions
+test-no-live = "pytest tests -m 'not live'"
+check = { depends-on = ["format", "lint", "type-check", "test-no-live"] }
+check-live = { depends-on = ["format", "lint", "type-check", "test"] }
 
 # Documentation tasks
 docs-build = "mkdocs build --clean"


### PR DESCRIPTION
## Summary

Modularization Step 3 audit finding: the `check` pixi task runs all tests including `tests/live/`, causing 14 failures in CI/cron environments due to geo-restrictions (Binance HTTP 451, Bybit HTTP 403) and an OKX factory roundtrip TypeError.

## Changes

- Add `test-no-live` task: `pytest tests -m 'not live'`
- Wire `check` to use `test-no-live` instead of `test`
- Add `check-live` as an explicit opt-in task for the full suite (including live tests)
- The `live` marker was already declared in `[tool.pytest.ini_options] markers`; this change activates the exclusion in the default task

## Follow-up suggestion

Add a dedicated `live-tests` CI job that runs `check-live` nightly with retries and geo-unblocked runners, rather than burying live tests in the standard dev loop.