### PR TITLE
ci: normalize to ci-framework (Wave 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       enable-hygiene-check: true
       editable-install: true
       package-path: "."
-      allowed-licenses: "MIT, Apache-2.0, BSD-3-Clause, BSD-2-Clause, ISC"
+      allowed-licenses: "MIT, Apache-2.0, BSD-3-Clause, BSD-2-Clause, ISC, PSF-2.0, LGPL-3.0"
 
   branch-policy:
     name: "Branch Policy"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,8 +1,9 @@
-name: Auto-Merge Dependabot PR
+---
+# Auto-merge dependabot PRs for minor and patch updates
+# Major version bumps still require manual review
+name: Dependabot Auto-Merge
 
-on:
-  pull_request_target:
-    types: [opened, synchronize, reopened]
+on: pull_request
 
 permissions:
   contents: write
@@ -10,16 +11,24 @@ permissions:
 
 jobs:
   auto-merge:
-    name: "Auto-Merge Dependabot PR"
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:
-      - name: Approve PR
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v3
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Auto-approve minor and patch updates
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Enable auto-merge
+
+      - name: Enable auto-merge for minor and patch updates
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,139 +1,16 @@
-name: Security Scanning
-
+name: Security
 on:
   push:
-    branches: [ main, development ]
+    branches: [main, development]
   pull_request:
-    branches: [ main, development ]
+    branches: [main, development]
   schedule:
-    # Run security scan weekly on Sundays at 2 AM UTC
-    - cron: '0 2 * * 0'
-
-permissions: read-all
-
+    - cron: '0 2 * * 0'   # weekly, Sunday 02:00 UTC (preserves existing cadence)
 jobs:
-  codeql:
-    name: CodeQL Security Analysis
-    runs-on: ubuntu-latest
-    timeout-minutes: 360
+  security:
+    uses: Claire-s-Monster/ci-framework/.github/workflows/reusable-security.yml@1a9f71d1ebbd0b1393938a05434af724276934e1  # v2.9.5
     permissions:
-      security-events: write
-      packages: read
-      actions: read
       contents: read
-
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-        - language: python
-          build-mode: none
-
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v6
-
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
-      with:
-        languages: ${{ matrix.language }}
-        build-mode: ${{ matrix.build-mode }}
-        queries: +security-and-quality
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
-      with:
-        category: "/language:${{matrix.language}}"
-
-  dependency-scan:
-    name: Dependency Vulnerability Scan
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v6
-
-    - name: Set up Python
-      uses: actions/setup-python@v6
-      with:
-        python-version: '3.12'
-
-    - name: Install dependencies
-      run: |
-        pip install --upgrade pip
-        pip install safety bandit
-
-    - name: Run Safety check
-      run: |
-        safety check --json --output safety-report.json || true
-
-    - name: Run Bandit security scan
-      run: |
-        bandit -r candles_feed/ -f json -o bandit-report.json || true
-
-    - name: Upload security reports
-      uses: actions/upload-artifact@v7
-      if: always()
-      with:
-        name: security-reports
-        path: |
-          safety-report.json
-          bandit-report.json
-
-  secrets-scan:
-    name: Secrets Detection
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v6
-
-    - name: Install detect-secrets
-      run: pip install detect-secrets
-
-    - name: Run secrets detection
-      run: |
-        detect-secrets scan --baseline .secrets.baseline --all-files
-        if [ $? -ne 0 ]; then
-          echo "::error::New secrets detected! Please review and update .secrets.baseline if legitimate."
-          exit 1
-        fi
-
-  security-summary:
-    name: Security Summary
-    runs-on: ubuntu-latest
-    needs: [codeql, dependency-scan, secrets-scan]
-    if: always()
-    steps:
-    - name: Security Status Summary
-      run: |
-        echo "## Security Scan Results" >> $GITHUB_STEP_SUMMARY
-        echo "| Scan Type | Status |" >> $GITHUB_STEP_SUMMARY
-        echo "|-----------|--------|" >> $GITHUB_STEP_SUMMARY
-        echo "| CodeQL | ${{ needs.codeql.result }} |" >> $GITHUB_STEP_SUMMARY
-        echo "| Dependencies | ${{ needs.dependency-scan.result }} |" >> $GITHUB_STEP_SUMMARY
-        echo "| Secrets | ${{ needs.secrets-scan.result }} |" >> $GITHUB_STEP_SUMMARY
-
-        if [[ "${{ needs.codeql.result }}" == "failure" || "${{ needs.dependency-scan.result }}" == "failure" || "${{ needs.secrets-scan.result }}" == "failure" ]]; then
-          echo "::error::One or more security scans failed. Please review the results."
-          exit 1
-        fi
-
-  # Summary job that reports overall security workflow status
-  security-status:
-    name: Security Scanning
-    runs-on: ubuntu-latest
-    needs: [codeql, dependency-scan, secrets-scan, security-summary]
-    if: always()
-    steps:
-      - name: Report Security Status
-        run: |
-          # Check if all security jobs passed
-          if [[ "${{ needs.codeql.result }}" == "success" && "${{ needs.dependency-scan.result }}" == "success" && "${{ needs.secrets-scan.result }}" == "success" ]]; then
-            echo "All Security Scanning jobs passed"
-            exit 0
-          else
-            echo "Some Security Scanning jobs failed"
-            echo "CodeQL result: ${{ needs.codeql.result }}"
-            echo "Dependency scan result: ${{ needs.dependency-scan.result }}"
-            echo "Secrets scan result: ${{ needs.secrets-scan.result }}"
-            exit 1
-          fi
+      actions: read
+      id-token: write
+    secrets: inherit


### PR DESCRIPTION
## CI-Framework Normalization — Wave 1 (candles-feed reference PR)

Part of the cross-sub-package ci-framework normalization effort so CI failures look the same everywhere.

### Changes
- **security.yml** -> delegates to `reusable-security.yml@v2.9.5`. Trades bandit/detect-secrets for Semgrep + OpenSSF Scorecard + pixi dep-audit + TruffleHog (net upgrade; behavior change accepted in spec). Preserves Sunday 02:00 UTC cadence.
- **dependabot-auto-merge.yml** -> canonical framework copy (`fetch-metadata@v3`, skips semver-major).
- **ci.yml** -> `allowed-licenses` unified to the 7-item list (+PSF-2.0, +LGPL-3.0).

### Reviewer note
The delegated security workflow's job/check names differ from the old `Security Scanning` checks. If branch protection lists `Security Scanning` (or CodeQL job names) as required status checks, update those references after merge.

## Summary by Sourcery

Normalize CI workflows to the shared ci-framework and align license and Dependabot policies across the repository.

Enhancements:
- Delegate the security workflow to the shared reusable security workflow while preserving the existing weekly schedule.
- Update the Dependabot auto-merge workflow to use the canonical configuration that only auto-approves and auto-merges non–semver-major updates.
- Expand the allowed license list in the main CI workflow to include PSF-2.0 and LGPL-3.0.

CI:
- Standardize security scanning, Dependabot auto-merge behavior, and license checks with the centralized ci-framework configuration.