### PR TITLE
ci: bump ci-framework to v2.9.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ permissions: {}
 
 jobs:
   ci:
-    uses: Claire-s-Monster/ci-framework/.github/workflows/reusable-ci.yml@1a9f71d1ebbd0b1393938a05434af724276934e1 # v2.9.5
+    uses: Claire-s-Monster/ci-framework/.github/workflows/reusable-ci.yml@dd7b8424ba3869283fab81f60aaec75cdac3168e # v2.9.6
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/cleanup-dev-files.yml
+++ b/.github/workflows/cleanup-dev-files.yml
@@ -30,7 +30,7 @@ on:
 jobs:
   cleanup:
     if: false
-    uses: Claire-s-Monster/ci-framework/.github/workflows/cleanup-dev-files.yml@1a9f71d1ebbd0b1393938a05434af724276934e1
+    uses: Claire-s-Monster/ci-framework/.github/workflows/cleanup-dev-files.yml@dd7b8424ba3869283fab81f60aaec75cdac3168e
     with:
       target_branches: >-
         ${{

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -8,7 +8,7 @@ on:
     - cron: '0 2 * * 0'   # weekly, Sunday 02:00 UTC (preserves existing cadence)
 jobs:
   security:
-    uses: Claire-s-Monster/ci-framework/.github/workflows/reusable-security.yml@1a9f71d1ebbd0b1393938a05434af724276934e1  # v2.9.5
+    uses: Claire-s-Monster/ci-framework/.github/workflows/reusable-security.yml@dd7b8424ba3869283fab81f60aaec75cdac3168e  # v2.9.6
     permissions:
       contents: read
       actions: read


### PR DESCRIPTION
Bumps the ci-framework pin from v2.9.5 (1a9f71d1) to v2.9.6 (dd7b8424) across ci.yml, security.yml, and cleanup-dev-files.yml. v2.9.6 gates reusable-ci CodeQL behind the codeql input (default false); reusable-security.yml owns CodeQL, so the duplicate codeql-python upload (neutral CodeQL check, #215) is resolved. Coverage unchanged.

## Summary by Sourcery

CI:
- Bump ci-framework reusable CI, security, and cleanup-dev-files workflows to commit dd7b8424 (v2.9.6).