### PR TITLE
chore(ci): bump ci-framework to v2.9.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ permissions: {}
 
 jobs:
   ci:
-    uses: Claire-s-Monster/ci-framework/.github/workflows/reusable-ci.yml@dd7b8424ba3869283fab81f60aaec75cdac3168e # v2.9.6
+    uses: Claire-s-Monster/ci-framework/.github/workflows/reusable-ci.yml@fe3991399e33c62e9b56a9336694ce4e9deb63c5 # v2.9.7
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/cleanup-dev-files.yml
+++ b/.github/workflows/cleanup-dev-files.yml
@@ -30,7 +30,7 @@ on:
 jobs:
   cleanup:
     if: false
-    uses: Claire-s-Monster/ci-framework/.github/workflows/cleanup-dev-files.yml@dd7b8424ba3869283fab81f60aaec75cdac3168e
+    uses: Claire-s-Monster/ci-framework/.github/workflows/cleanup-dev-files.yml@fe3991399e33c62e9b56a9336694ce4e9deb63c5  # v2.9.7
     with:
       target_branches: >-
         ${{

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -8,7 +8,7 @@ on:
     - cron: '0 2 * * 0'   # weekly, Sunday 02:00 UTC (preserves existing cadence)
 jobs:
   security:
-    uses: Claire-s-Monster/ci-framework/.github/workflows/reusable-security.yml@dd7b8424ba3869283fab81f60aaec75cdac3168e  # v2.9.6
+    uses: Claire-s-Monster/ci-framework/.github/workflows/reusable-security.yml@fe3991399e33c62e9b56a9336694ce4e9deb63c5  # v2.9.7
     permissions:
       contents: read
       actions: read


### PR DESCRIPTION
Bumps the Claire-s-Monster/ci-framework pin from **v2.9.6** (`dd7b8424`) to **v2.9.7** (`fe399139`) across all three workflow files that reference it: `ci.yml`, `security.yml`, and `cleanup-dev-files.yml` (the last previously had no version comment — now `# v2.9.7`).

v2.9.7 is two `fix(ci)` patches, no interface/breaking changes:
- `reusable-security.yml`: CodeQL `upload: true` — **fixes the neutral `CodeQL` check** (this package consumes `security.yml`)
- `gemini-ai-analysis.yml`: adds a `permissions:` block (fixes startup_failure)

Supersedes the redundant #71 (which only re-bumped to v2.9.6).

Part of the blanket v2.9.7 bump across all 14 hb-* sub-packages.

## Summary by Sourcery

CI:
- Update all workflows referencing Claire-s-Monster/ci-framework from v2.9.6 to v2.9.7, including adding a version comment to the cleanup-dev-files workflow.