### PR TITLE
feat(build): HB_COMPILE_AUGMENTED-gated build hook for augmented DataProcessor (#76)

### DIFF
--- a/hatch_build.py
+++ b/hatch_build.py
@@ -1,0 +1,96 @@
+"""Hatchling build hook for candles-feed — issue #76, Phase 3 (compile-on-accelerated).
+
+PASSIVE BY DEFAULT. This hook is a strict no-op unless the environment variable
+``HB_COMPILE_AUGMENTED`` is truthy (one of ``{1, true, yes, on}``, case-insensitive).
+Under a normal install — and under the hummingbot gate's editable install — it adds
+ZERO dependencies and produces the current pure-Python behavior (AC1).
+
+When ``HB_COMPILE_AUGMENTED`` is set, it delegates to the maintainer-local
+``hb-cython-framework`` build hook, which discovers augmented-pure-python modules by
+pragma (``# cython: augmented_pure_python=True``, via the framework's ``is_augmented``
+scan — no central manifest) and compiles them (e.g. ``data_processor.py`` -> ``.so``)
+with Cython (AC2).
+
+PUBLISHING BOUNDARY (AC3). ``cython`` is never added to ``[project.dependencies]`` and
+``hb-cython-framework`` is never added to ``[build-system].requires`` or runtime deps.
+Real Cython is build/dev-only and exposed via the optional ``candles-feed[accelerated]``
+extra. The framework hook is referenced ONLY via a lazy, guarded import that runs solely
+when ``HB_COMPILE_AUGMENTED`` is set; the framework is supplied on the build path by the
+hummingbot accelerated env (orchestrator-owned), never by this package's published
+metadata. The hook FAILS CLOSED — it skips compilation instead of raising — when the
+framework is unavailable, so a plain dev install never breaks.
+
+The accelerated-tier wiring that actually sets ``HB_COMPILE_AUGMENTED=1`` and provides the
+framework on the build path is out of scope here (orchestrator-owned; lives in the
+hummingbot ``_for_accel/cython-framework`` branch).
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from typing import Any
+
+#: Environment gate that opts a build into compiling the augmented modules.
+_ENV_GATE = "HB_COMPILE_AUGMENTED"
+
+#: Truthy spellings that enable the accelerated (native) compile.
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+
+def _accelerated_build_requested(environ: Mapping[str, str] | None = None) -> bool:
+    """Return True iff the accelerated compile is explicitly requested (AC1)."""
+    env = os.environ if environ is None else environ
+    return env.get(_ENV_GATE, "").strip().lower() in _TRUTHY
+
+
+def _delegate_to_framework(
+    hook: BuildHookInterface, version: str, build_data: dict[str, Any]
+) -> bool:
+    """Lazily import and run the hb-cython-framework build hook.
+
+    Returns True if compilation was delegated, or False if the framework was
+    unavailable (fail-closed skip per AC3). Genuine compile errors raised by the
+    framework are allowed to propagate, so an accelerated build never silently
+    ships an uncompiled wheel.
+    """
+    try:
+        from cython_framework.buildhook.hook import AugmentedCythonBuildHook
+    except ImportError as exc:  # AC3: fail closed — framework not on the build path.
+        hook.app.display_warning(
+            f"{_ENV_GATE} is set but hb-cython-framework is unavailable "
+            f"({exc}); skipping augmented compilation and building the passive "
+            f"pure-Python wheel."
+        )
+        return False
+
+    # Both hooks derive from hatchling's BuildHookInterface, so the framework
+    # hook is reconstructed from the exact arguments hatchling handed us.
+    framework_hook = AugmentedCythonBuildHook(
+        hook.root,
+        hook.config,
+        hook.build_config,
+        hook.metadata,
+        hook.directory,
+        hook.target_name,
+        hook.app,
+    )
+    framework_hook.initialize(version, build_data)
+    return True
+
+
+class CandlesFeedBuildHook(BuildHookInterface):
+    """Compile augmented modules only when explicitly gated; otherwise a no-op."""
+
+    PLUGIN_NAME = "custom"
+
+    def initialize(self, version: str, build_data: dict[str, Any]) -> None:
+        if not _accelerated_build_requested():
+            # AC1: passive by default — no framework import, no Cython, no deps.
+            return
+        _delegate_to_framework(self, version, build_data)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,17 @@ doc = [
     "pymdown-extensions>=8.0.0",
 ]
 hummingbot = []
+# Accelerated (compile-on-accelerated) build tier — issue #76, Phase 3.
+# Exposes REAL Cython for the optional native compile of augmented-pure-python
+# modules; installed via `pip install candles-feed[accelerated]`. Build/dev-only:
+# it adds NOTHING to the passive runtime (AC1/AC3). The maintainer-local
+# hb-cython-framework is deliberately NOT listed here — it is unpublished and is
+# supplied on the build path by the hummingbot accelerated env / the `accel` pixi
+# env, never by this package's published metadata. The build hook (hatch_build.py)
+# imports it lazily and fails closed if it is absent.
+accelerated = [
+    "Cython>=3.2.4",
+]
 
 # Pixi configuration
 [tool.pixi.workspace]
@@ -87,6 +98,12 @@ path = "candles_feed/__about__.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["candles_feed"]
+
+# Repo-owned build hook (hatch_build.py) — issue #76, Phase 3. Passive no-op
+# unless HB_COMPILE_AUGMENTED is truthy; then it delegates to hb-cython-framework
+# to compile augmented-pure-python modules to native extensions. See hatch_build.py.
+[tool.hatch.build.targets.wheel.hooks.custom]
+path = "hatch_build.py"
 
 # Conda dependencies
 # Note: prometheus_client (underscore) is available on conda-forge and included in pixi dev dependencies.

--- a/tests/unit/core/test_augmented_build_hook.py
+++ b/tests/unit/core/test_augmented_build_hook.py
@@ -65,6 +65,48 @@ def test_delegate_fails_closed_when_framework_missing(monkeypatch):
     assert warnings and "hb-cython-framework is unavailable" in warnings[0]
 
 
+def test_delegate_succeeds_and_reconstructs_hook_args(monkeypatch):
+    """Gate on and framework present -> construct the framework hook from the
+    exact hatchling args, call initialize(), and return True (AC2 delegation)."""
+    recorded = {}
+
+    class _StubFrameworkHook:
+        def __init__(self, root, config, build_config, metadata, directory, target_name, app):
+            recorded["ctor"] = (root, config, build_config, metadata, directory, target_name, app)
+
+        def initialize(self, version, build_data):
+            recorded["init"] = (version, build_data)
+
+    fake_module = SimpleNamespace(AugmentedCythonBuildHook=_StubFrameworkHook)
+    for _name in ("cython_framework", "cython_framework.buildhook"):
+        monkeypatch.setitem(sys.modules, _name, SimpleNamespace())
+    monkeypatch.setitem(sys.modules, "cython_framework.buildhook.hook", fake_module)
+
+    hook = SimpleNamespace(
+        root="/repo",
+        config={"path": "hatch_build.py"},
+        build_config={"bc": 1},
+        metadata="META",
+        directory="/dist",
+        target_name="wheel",
+        app=SimpleNamespace(display_warning=lambda *_args, **_kwargs: None),
+    )
+
+    delegated = hatch_build._delegate_to_framework(hook, "3.0.0", {"pure_python": False})
+
+    assert delegated is True
+    assert recorded["ctor"] == (
+        "/repo",
+        {"path": "hatch_build.py"},
+        {"bc": 1},
+        "META",
+        "/dist",
+        "wheel",
+        hook.app,
+    )
+    assert recorded["init"] == ("3.0.0", {"pure_python": False})
+
+
 def test_initialize_under_gate_delegates(monkeypatch):
     """Gate on -> initialize() routes through _delegate_to_framework (AC2 dispatch)."""
     monkeypatch.setenv("HB_COMPILE_AUGMENTED", "1")

--- a/tests/unit/core/test_augmented_build_hook.py
+++ b/tests/unit/core/test_augmented_build_hook.py
@@ -1,0 +1,83 @@
+"""Unit tests for the augmented-compile build hook (issue #76, Phase 3).
+
+These exercise the hook's env gate and fail-closed contract WITHOUT requiring the
+maintainer-local ``hb-cython-framework`` or a C toolchain, so they run in every
+environment. Compiled-vs-passive behaviour parity is covered separately by
+``test_data_processor_parity.py`` (run in the ``accel`` env).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("hatchling", reason="hatchling (build backend) not installed")
+
+# hatch_build.py is a root-level build module, not a package member; load by path.
+_HOOK_PATH = Path(__file__).resolve().parents[3] / "hatch_build.py"
+_spec = importlib.util.spec_from_file_location("candles_feed_hatch_build", _HOOK_PATH)
+hatch_build = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(hatch_build)
+
+
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", "Yes", "on", " on "])
+def test_gate_truthy_values_enable_compile(value):
+    assert hatch_build._accelerated_build_requested({"HB_COMPILE_AUGMENTED": value}) is True
+
+
+@pytest.mark.parametrize("value", ["", "0", "false", "no", "off", "maybe"])
+def test_gate_falsy_values_stay_passive(value):
+    assert hatch_build._accelerated_build_requested({"HB_COMPILE_AUGMENTED": value}) is False
+
+
+def test_gate_absent_is_passive():
+    assert hatch_build._accelerated_build_requested({}) is False
+
+
+def test_passive_initialize_is_strict_noop(monkeypatch):
+    """Gate off -> initialize() must never consult the framework (AC1)."""
+    monkeypatch.delenv("HB_COMPILE_AUGMENTED", raising=False)
+
+    def _boom(*_args, **_kwargs):
+        raise AssertionError("framework must not be consulted in passive mode")
+
+    monkeypatch.setattr(hatch_build, "_delegate_to_framework", _boom)
+
+    hook = hatch_build.CandlesFeedBuildHook.__new__(hatch_build.CandlesFeedBuildHook)
+    hook.initialize("1.0.0", {})  # returns without touching hatchling state
+
+
+def test_delegate_fails_closed_when_framework_missing(monkeypatch):
+    """Gate on but framework absent -> warn, skip, return False; never raise (AC3)."""
+    warnings: list[str] = []
+    fake_hook = SimpleNamespace(app=SimpleNamespace(display_warning=warnings.append))
+
+    # Force the lazy import to fail even if the framework happens to be installed.
+    monkeypatch.setitem(sys.modules, "cython_framework.buildhook.hook", None)
+
+    delegated = hatch_build._delegate_to_framework(fake_hook, "1.0.0", {})
+
+    assert delegated is False
+    assert warnings and "hb-cython-framework is unavailable" in warnings[0]
+
+
+def test_initialize_under_gate_delegates(monkeypatch):
+    """Gate on -> initialize() routes through _delegate_to_framework (AC2 dispatch)."""
+    monkeypatch.setenv("HB_COMPILE_AUGMENTED", "1")
+
+    captured = {}
+
+    def _capture(_hook, version, build_data):
+        captured["call"] = (version, build_data)
+        return True
+
+    monkeypatch.setattr(hatch_build, "_delegate_to_framework", _capture)
+
+    hook = hatch_build.CandlesFeedBuildHook.__new__(hatch_build.CandlesFeedBuildHook)
+    hook.initialize("2.0.0", {"k": "v"})
+
+    assert captured["call"] == ("2.0.0", {"k": "v"})

--- a/tests/unit/core/test_data_processor_parity.py
+++ b/tests/unit/core/test_data_processor_parity.py
@@ -13,6 +13,7 @@ installed (e.g. minimal/CI-lite environments), so this file carries no
 from __future__ import annotations
 
 import importlib.util
+import os
 from collections import deque
 from datetime import datetime
 from pathlib import Path
@@ -22,11 +23,22 @@ import pytest
 from candles_feed.core import data_processor as passive_dp
 from candles_feed.core.candle_data import CandleData
 
-variant_builder = pytest.importorskip(
-    "cython_framework.buildhook.variant_builder",
-    reason="hb-cython-framework not installed (dev/CI-only)",
-)
-pytest.importorskip("Cython")
+# Under the accelerated gate (HB_COMPILE_AUGMENTED truthy) the compiled variant
+# MUST be buildable, so a missing framework/Cython is a hard failure rather than
+# a skip — this is the compiled-variant assertion "exercised under
+# HB_COMPILE_AUGMENTED=1" (issue #76 AC4). When the gate is unset the module
+# skips cleanly in framework-less environments, exactly as before.
+_GATE_ON = os.environ.get("HB_COMPILE_AUGMENTED", "").strip().lower() in {"1", "true", "yes", "on"}
+
+if _GATE_ON:
+    variant_builder = importlib.import_module("cython_framework.buildhook.variant_builder")
+    importlib.import_module("Cython")
+else:
+    variant_builder = pytest.importorskip(
+        "cython_framework.buildhook.variant_builder",
+        reason="hb-cython-framework not installed (dev/CI-only)",
+    )
+    pytest.importorskip("Cython")
 
 
 @pytest.fixture(scope="module")
@@ -44,6 +56,8 @@ def compiled_dp(tmp_path_factory):
             variants=[CythonModuleType.COMPILED_AUGMENTED_PYTHON],
         )
     except variant_builder.VariantBuildError as exc:
+        if _GATE_ON:
+            raise
         pytest.skip(f"compiled variant unavailable (toolchain): {exc}")
 
     so_path = Path(artifacts[CythonModuleType.COMPILED_AUGMENTED_PYTHON])


### PR DESCRIPTION
Closes #76 — Phase 3 (compile-on-accelerated).

Adds a repo-owned Hatchling **wheel** build hook (`hatch_build.py`) that is a strict no-op unless `HB_COMPILE_AUGMENTED` is truthy (`{1,true,yes,on}`). When set, it delegates to the maintainer-local `hb-cython-framework` hook via a **lazy, guarded import** to compile augmented-pure-python modules (`data_processor.py` → `.so`) discovered by the `# cython: augmented_pure_python=True` pragma scan.

### Acceptance criteria
- **AC1 — passive by default.** No framework import, no Cython, zero deps when the gate is unset. Editable/`pip install -e .` is unaffected (hook is wheel-target only).
- **AC2 — pragma-driven compile.** Discovery + compilation delegate to the framework's `is_augmented` scan (no manifest).
- **AC3 — publishing boundary intact.** `cython` is **not** in `[project.dependencies]`; `hb-cython-framework` is **not** in `[build-system].requires` or runtime deps. Real Cython is exposed build/dev-only via the new optional `candles-feed[accelerated]` extra. The framework is referenced only via a lazy guarded import that runs solely under the gate and **fails closed** (skips, never raises) when unavailable — supplied on the build path by the accelerated env (orchestrator-owned).
- **AC4 — parity in both modes.** Compiled-vs-passive behaviour parity remains covered by `test_data_processor_parity.py` (accel env). New `tests/unit/core/test_augmented_build_hook.py` asserts the gate parsing, passive strict-no-op, gated dispatch, and fail-closed-on-missing-framework contract.

### Notes / boundaries
- **Out of scope (orchestrator-owned):** the accelerated-tier wiring that sets `HB_COMPILE_AUGMENTED=1` and provides the framework on the build path (hummingbot `_for_accel/cython-framework`).
- `default`/`ci`/`py312` pixi envs are **unchanged** (pure-conda, identical to development, per #75). The hook test uses `importorskip("hatchling")` so it runs in the `accel` env (which pulls hatchling transitively) and skips cleanly in pure-conda envs — deliberately avoiding adding `hatchling` to the shared `dev` feature, which would invalidate the `accel` git-dep lock. `pixi.lock` is untouched.

### Local verification
- New hook unit tests: **16/16 pass** (with hatchling present); `hatch_build.py` imports cleanly.
- `ruff format --check` ✅ · `ruff check` ✅ · `mypy candles_feed` ✅.
- Real Cython compilation is validated by CI's accel job (needs the framework git dep + toolchain), not locally offline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce an optional accelerated build path that compiles augmented-pure-Python modules when explicitly gated, while keeping the default wheel build strictly passive and dependency-free.

New Features:
- Add an optional `accelerated` extra exposing Cython for native compilation in gated build environments.
- Register a custom Hatchling wheel build hook to integrate the augmented compile flow under an environment gate.

Enhancements:
- Implement a gated, fail-closed build hook that delegates augmented module compilation to the maintainer-local framework only when requested.

Tests:
- Add unit tests covering the build hook’s environment gate parsing, passive no-op behavior, gated delegation, and fail-closed behavior when the framework is unavailable.