### PR TITLE
chore(gitignore): stop re-including cythonized C output under candles_feed/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,10 +64,11 @@ site/
 mkdocs.saved.yml
 
 # Cython generated files
+# candles_feed/ has no hand-written C sources: every *.c/*.cpp under it is
+# cythonized output from the HB_COMPILE_AUGMENTED build hook, same as the
+# *.so it links into (ignored above). Do not re-include them.
 *.c
 *.cpp
-!candles_feed/**/*.c
-!candles_feed/**/*.cpp
 
 # CMake
 _skbuild/


### PR DESCRIPTION
## Problem

The `# Cython generated files` block ignored `*.c`/`*.cpp` and then immediately negated both for `candles_feed/**` — the one directory the build actually writes generated C into:

```gitignore
# Cython generated files
*.c
*.cpp
!candles_feed/**/*.c      # <- re-includes exactly where the build writes
!candles_feed/**/*.cpp
```

The negation has no legitimate target: `candles_feed/` contains **no hand-written C sources**. Every `*.c`/`*.cpp` under it is cythonized output from the `HB_COMPILE_AUGMENTED` build hook (#76 / #77) — the same `pixi run build` step the gates run before each full suite.

The tell was the **asymmetry with `*.so`**, which line 5 ignores unconditionally. Both the `.c` and the `.so` come out of that one build step; ignoring the shared object while tracking the C it was compiled from cannot have been intentional.

## Fix

Drop the two negations so `*.c`/`*.cpp` behave like `*.so`, and leave a comment explaining why they must not come back.

## Scope

This closes a **latent** hole rather than cleaning up committed artifacts. Verified at `35ed1f0`: no `*.c`, `*.cpp`, `*.pyx`, or `*.pxd` exists in the source tree outside `.pixi/envs/`, and the tree is clean — so nothing generated is currently tracked and no file is untracked by this change.

One loose end this PR does **not** address: the survey excluded `.worktrees/`, so a previously generated `.c` may still sit on disk in one of the other worktrees. This change prevents recurrence; it does not delete an existing stray artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Chores:
- Clarify .gitignore intent around candles_feed Cython output to prevent future reintroduction of generated C/C++ files.